### PR TITLE
Retry also when disconnected by the server

### DIFF
--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -5,6 +5,7 @@ from ssl import CERT_NONE, SSLError, CertificateError, create_default_context
 
 import imapclient
 import imapclient.exceptions
+import imaplib
 
 import mailsuite.utils
 
@@ -227,7 +228,7 @@ class IMAPClient(imapclient.IMAPClient):
         """
         try:
             raw_msg = self.fetch(msg_uid, ["RFC822"])[msg_uid]
-        except (socket.timeout, BrokenPipeError):
+        except (socket.timeout, imaplib.IMAP4.abort):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:
                 raise MaxRetriesExceeded("Maximum retries exceeded")
@@ -264,7 +265,7 @@ class IMAPClient(imapclient.IMAPClient):
             imapclient.IMAPClient.delete_messages(self, msg_uids,
                                                   silent=silent)
             imapclient.IMAPClient.expunge(self, msg_uids)
-        except (socket.timeout, BrokenPipeError):
+        except (socket.timeout, imaplib.IMAP4.abort):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:
                 raise MaxRetriesExceeded("Maximum retries exceeded")
@@ -286,7 +287,7 @@ class IMAPClient(imapclient.IMAPClient):
             logger.info("Creating folder: {0}".format(folder_path))
             try:
                 imapclient.IMAPClient.create_folder(self, folder_path)
-            except (socket.timeout, BrokenPipeError):
+            except (socket.timeout, imaplib.IMAP4.abort):
                 _attempt = _attempt + 1
                 if _attempt > self.max_retries:
                     raise MaxRetriesExceeded("Maximum retries exceeded")
@@ -344,7 +345,7 @@ class IMAPClient(imapclient.IMAPClient):
         """
         try:
             self._move_messages(msg_uids, folder_path)
-        except (socket.timeout, BrokenPipeError):
+        except (socket.timeout, imaplib.IMAP4.abort):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:
                 raise MaxRetriesExceeded("Maximum retries exceeded")

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -227,7 +227,7 @@ class IMAPClient(imapclient.IMAPClient):
         """
         try:
             raw_msg = self.fetch(msg_uid, ["RFC822"])[msg_uid]
-        except (socket.timeout, socket.errno):
+        except (socket.timeout, BrokenPipeError):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:
                 raise MaxRetriesExceeded("Maximum retries exceeded")
@@ -264,7 +264,7 @@ class IMAPClient(imapclient.IMAPClient):
             imapclient.IMAPClient.delete_messages(self, msg_uids,
                                                   silent=silent)
             imapclient.IMAPClient.expunge(self, msg_uids)
-        except (socket.timeout, socket.errno):
+        except (socket.timeout, BrokenPipeError):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:
                 raise MaxRetriesExceeded("Maximum retries exceeded")
@@ -286,7 +286,7 @@ class IMAPClient(imapclient.IMAPClient):
             logger.info("Creating folder: {0}".format(folder_path))
             try:
                 imapclient.IMAPClient.create_folder(self, folder_path)
-            except (socket.timeout, socket.errno):
+            except (socket.timeout, BrokenPipeError):
                 _attempt = _attempt + 1
                 if _attempt > self.max_retries:
                     raise MaxRetriesExceeded("Maximum retries exceeded")
@@ -344,7 +344,7 @@ class IMAPClient(imapclient.IMAPClient):
         """
         try:
             self._move_messages(msg_uids, folder_path)
-        except (socket.timeout, socket.errno):
+        except (socket.timeout, BrokenPipeError):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:
                 raise MaxRetriesExceeded("Maximum retries exceeded")

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -227,7 +227,7 @@ class IMAPClient(imapclient.IMAPClient):
         """
         try:
             raw_msg = self.fetch(msg_uid, ["RFC822"])[msg_uid]
-        except socket.timeout:
+        except (socket.timeout, socket.errno):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:
                 raise MaxRetriesExceeded("Maximum retries exceeded")
@@ -264,7 +264,7 @@ class IMAPClient(imapclient.IMAPClient):
             imapclient.IMAPClient.delete_messages(self, msg_uids,
                                                   silent=silent)
             imapclient.IMAPClient.expunge(self, msg_uids)
-        except socket.timeout:
+        except (socket.timeout, socket.errno):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:
                 raise MaxRetriesExceeded("Maximum retries exceeded")
@@ -286,7 +286,7 @@ class IMAPClient(imapclient.IMAPClient):
             logger.info("Creating folder: {0}".format(folder_path))
             try:
                 imapclient.IMAPClient.create_folder(self, folder_path)
-            except socket.timeout:
+            except (socket.timeout, socket.errno):
                 _attempt = _attempt + 1
                 if _attempt > self.max_retries:
                     raise MaxRetriesExceeded("Maximum retries exceeded")
@@ -344,7 +344,7 @@ class IMAPClient(imapclient.IMAPClient):
         """
         try:
             self._move_messages(msg_uids, folder_path)
-        except socket.timeout:
+        except (socket.timeout, socket.errno):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:
                 raise MaxRetriesExceeded("Maximum retries exceeded")


### PR DESCRIPTION
When processing big messages (ie. on parsedmarc) the connection stays idle for too long and the server might close the connection. In this case we need to be able to retry.