### PR TITLE
Revert namechange of _normalise_folder method

### DIFF
--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -27,7 +27,7 @@ def _chunks(list_like_object, n: int):
 class IMAPClient(imapclient.IMAPClient):
     """A simplified IMAP client"""
 
-    def _normalize_folder(self, folder_name: str) -> str:
+    def _normalise_folder(self, folder_name: str) -> str:
         """
         Returns an appropriate path based on the namespace (if any) and
         hierarchy separator
@@ -39,7 +39,7 @@ class IMAPClient(imapclient.IMAPClient):
             A corrected path
         """
         if folder_name in ["", "*", "INBOX"]:
-            return imapclient.IMAPClient._normalize_folder(self, folder_name)
+            return imapclient.IMAPClient._normalise_folder(self, folder_name)
         folder_name = folder_name.rstrip("/")
         folder_name = folder_name.replace(self._path_prefix, "")
         if not self._hierarchy_separator == "/":
@@ -47,7 +47,7 @@ class IMAPClient(imapclient.IMAPClient):
             folder_name = folder_name.replace("/", self._hierarchy_separator)
         folder_name = "{0}{1}".format(self._path_prefix, folder_name)
 
-        return imapclient.IMAPClient._normalize_folder(self, folder_name)
+        return imapclient.IMAPClient._normalise_folder(self, folder_name)
 
     def _start_idle(self, idle_callback, idle_timeout: int = 30):
         """


### PR DESCRIPTION
Fixes #10

By manually applying all of the changes in https://github.com/seanthegeek/mailsuite/compare/a2f3b19fa5de9b743491eaaab39b781848563680...01cb8a8b899e1845518fc92de229ea6a2b82047d to see which was to blame, it turned out to be the renaming of `_normalise_folder`. This is due to the fact that it attempts to override and subsequently call the same method on `IMAPClient` from the `imapclient` package, which is named `_normalise_folder` and thus cannot be called nor overridden with a different name.