### PR TITLE
Add mailsuite.mailbox abstraction (IMAP and Maildir)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.13.0
+
+- Add `mailsuite.mailbox`, a provider-agnostic mailbox abstraction lifted from `parsedmarc`
+  - `MailboxConnection` ABC with `create_folder`, `fetch_messages`, `fetch_message`, `delete_message`, `move_message`, `keepalive`, `watch`, and `send_message`
+  - `IMAPConnection` (built on `mailsuite.imap.IMAPClient`, IDLE-based watch loop)
+  - `MaildirConnection` (built on the stdlib `mailbox.Maildir`)
+  - `send_message()` raises `NotImplementedError` on receive-only backends; use `mailsuite.smtp.send_email` for standalone sending. Microsoft Graph and Gmail backends with native `send_message()` support land in a follow-up release.
+
 ## 1.12.0
 
 - Add a new `mailsuite.dkim` module for DKIM key generation, public key extraction, TXT record generation, email signing, and signature verification

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,18 @@ mailsuite.dkim
    :members:
 ```
 
+mailsuite.mailbox
+-----------------
+
+```{eval-rst}
+.. automodule:: mailsuite.mailbox.base
+   :members:
+.. automodule:: mailsuite.mailbox.imap
+   :members:
+.. automodule:: mailsuite.mailbox.maildir
+   :members:
+```
+
 mailsuite.utils
 ---------------
 

--- a/mailsuite/__init__.py
+++ b/mailsuite/__init__.py
@@ -1,3 +1,3 @@
 """A Python package to simplify receiving, parsing, and sending email"""
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"

--- a/mailsuite/mailbox/__init__.py
+++ b/mailsuite/mailbox/__init__.py
@@ -1,0 +1,15 @@
+"""Provider-agnostic mailbox abstractions
+
+Lifted from parsedmarc so any application can read/manage mail across IMAP,
+Microsoft Graph, Gmail, or a local Maildir behind a single interface.
+"""
+
+from mailsuite.mailbox.base import MailboxConnection
+from mailsuite.mailbox.imap import IMAPConnection
+from mailsuite.mailbox.maildir import MaildirConnection
+
+__all__ = [
+    "MailboxConnection",
+    "IMAPConnection",
+    "MaildirConnection",
+]

--- a/mailsuite/mailbox/base.py
+++ b/mailsuite/mailbox/base.py
@@ -1,0 +1,96 @@
+"""Abstract base class for mailbox connections"""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import Any, Callable, Optional, Tuple
+
+
+class MailboxConnection(ABC):
+    """
+    A provider-agnostic interface for a mailbox
+
+    Subclasses implement the methods for a specific protocol (IMAP, Microsoft
+    Graph, Gmail, Maildir, etc.). Methods that don't apply to a given backend
+    raise :class:`NotImplementedError`.
+    """
+
+    def create_folder(self, folder_name: str) -> None:
+        """Create a folder/label in the mailbox"""
+        raise NotImplementedError
+
+    def fetch_messages(self, reports_folder: str, **kwargs: Any) -> list:
+        """Return a list of message identifiers in the given folder"""
+        raise NotImplementedError
+
+    def fetch_message(self, message_id: Any, **kwargs: Any) -> str:
+        """Fetch the raw RFC 822 contents of a message by identifier"""
+        raise NotImplementedError
+
+    def delete_message(self, message_id: Any) -> None:
+        """Permanently delete a message by identifier"""
+        raise NotImplementedError
+
+    def move_message(self, message_id: Any, folder_name: str) -> None:
+        """Move a message to the named folder"""
+        raise NotImplementedError
+
+    def keepalive(self) -> None:
+        """Send a no-op to keep the connection alive (if applicable)"""
+        raise NotImplementedError
+
+    def watch(
+        self,
+        check_callback: Callable[["MailboxConnection"], None],
+        check_timeout: int,
+        config_reloading: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        """
+        Watch the mailbox for new messages, invoking ``check_callback`` when
+        new mail arrives or on a polling interval
+
+        Args:
+            check_callback: Called with this :class:`MailboxConnection`
+                instance whenever the watcher fires.
+            check_timeout: Polling interval (or IDLE timeout) in seconds.
+            config_reloading: Optional zero-argument callable. When it returns
+                a truthy value, the watcher exits cleanly so the caller can
+                reload configuration.
+        """
+        raise NotImplementedError
+
+    def send_message(
+        self,
+        message_from: str,
+        message_to: Optional[list[str]] = None,
+        message_cc: Optional[list[str]] = None,
+        message_bcc: Optional[list[str]] = None,
+        subject: Optional[str] = None,
+        message_headers: Optional[dict] = None,
+        attachments: Optional[list[Tuple[str, bytes]]] = None,
+        plain_message: Optional[str] = None,
+        html_message: Optional[str] = None,
+    ) -> Optional[str]:
+        """
+        Send a message through this mailbox's native send API (when supported)
+
+        Backends without a native send (IMAP, Maildir) raise
+        :class:`NotImplementedError`. Use :func:`mailsuite.smtp.send_email`
+        directly when you need to send mail without a mailbox.
+
+        Args:
+            message_from: The value of the ``From`` header
+            message_to: A list of recipient addresses
+            message_cc: A list of Cc addresses
+            message_bcc: A list of Bcc addresses
+            subject: The message subject
+            message_headers: Additional headers
+            attachments: A list of ``(filename, bytes)`` tuples
+            plain_message: The plain-text body
+            html_message: The HTML body
+
+        Returns:
+            A provider-specific message identifier when available, otherwise
+            ``None``.
+        """
+        raise NotImplementedError

--- a/mailsuite/mailbox/imap.py
+++ b/mailsuite/mailbox/imap.py
@@ -1,0 +1,137 @@
+"""IMAP mailbox backend"""
+
+from __future__ import annotations
+
+import logging
+from socket import timeout
+from time import sleep
+from typing import Any, Callable, Optional, cast
+
+from imapclient.exceptions import IMAPClientError
+
+from mailsuite.imap import IMAPClient
+from mailsuite.mailbox.base import MailboxConnection
+
+logger = logging.getLogger(__name__)
+
+
+class IMAPConnection(MailboxConnection):
+    """
+    A :class:`MailboxConnection` backed by IMAP
+
+    Wraps :class:`mailsuite.imap.IMAPClient` and adds the
+    :class:`MailboxConnection` semantics (folder/label management, polling
+    via IDLE, etc.).
+
+    IMAP is a receive-only protocol — :meth:`send_message` raises
+    :class:`NotImplementedError`. Use :func:`mailsuite.smtp.send_email` for
+    sending.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        user: str,
+        password: str,
+        port: int = 993,
+        ssl: bool = True,
+        verify: bool = True,
+        timeout: int = 30,
+        max_retries: int = 4,
+    ):
+        self._username = user
+        self._password = password
+        self._verify = verify
+        self._client = IMAPClient(
+            host,
+            user,
+            password,
+            port=port,
+            ssl=ssl,
+            verify=verify,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+
+    def create_folder(self, folder_name: str) -> None:
+        self._client.create_folder(folder_name)
+
+    def fetch_messages(self, reports_folder: str, **kwargs: Any) -> list:
+        self._client.select_folder(reports_folder)
+        since = kwargs.get("since")
+        if since is not None:
+            return self._client.search(f"SINCE {since}")
+        return self._client.search()
+
+    def fetch_message(self, message_id: Any, **kwargs: Any) -> str:
+        return cast(str, self._client.fetch_message(message_id, parse=False))
+
+    def delete_message(self, message_id: Any) -> None:
+        try:
+            self._client.delete_messages([message_id])
+        except IMAPClientError as error:
+            logger.warning(
+                "IMAP delete fallback for message %s due to server error: %s",
+                message_id,
+                error,
+            )
+            self._client.add_flags([message_id], [r"\Deleted"], silent=True)
+            self._client.expunge()
+
+    def move_message(self, message_id: Any, folder_name: str) -> None:
+        try:
+            self._client.move_messages([message_id], folder_name)
+        except IMAPClientError as error:
+            logger.warning(
+                "IMAP move fallback for message %s due to server error: %s",
+                message_id,
+                error,
+            )
+            self._client.copy([message_id], folder_name)
+            self.delete_message(message_id)
+
+    def keepalive(self) -> None:
+        self._client.noop()
+
+    def watch(
+        self,
+        check_callback: Callable[[MailboxConnection], None],
+        check_timeout: int,
+        config_reloading: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        """
+        Watch for new messages over an IDLE connection and dispatch each batch
+        to ``check_callback``
+        """
+
+        def idle_callback_wrapper(client: IMAPClient) -> None:
+            self._client = client
+            check_callback(self)
+
+        while True:
+            if config_reloading and config_reloading():
+                return
+            try:
+                IMAPClient(
+                    host=self._client.host,
+                    username=self._username,
+                    password=self._password,
+                    port=self._client.port,
+                    ssl=self._client.ssl,
+                    verify=self._verify,
+                    idle_callback=idle_callback_wrapper,
+                    idle_timeout=check_timeout,
+                )
+            except (timeout, IMAPClientError):
+                logger.warning("IMAP connection timeout. Reconnecting...")
+                sleep(check_timeout)
+            except Exception as e:
+                logger.warning("IMAP connection error. {0}. Reconnecting...".format(e))
+                sleep(check_timeout)
+            if config_reloading and config_reloading():
+                return
+
+    def send_message(self, *args: Any, **kwargs: Any) -> Optional[str]:
+        raise NotImplementedError(
+            "IMAP cannot send mail; use mailsuite.smtp.send_email"
+        )

--- a/mailsuite/mailbox/maildir.py
+++ b/mailsuite/mailbox/maildir.py
@@ -1,0 +1,133 @@
+"""Maildir mailbox backend"""
+
+from __future__ import annotations
+
+import logging
+import mailbox
+import os
+from time import sleep
+from typing import Any, Callable, Dict, Optional
+
+from mailsuite.mailbox.base import MailboxConnection
+
+logger = logging.getLogger(__name__)
+
+
+class MaildirConnection(MailboxConnection):
+    """
+    A :class:`MailboxConnection` backed by an on-disk Maildir
+
+    Useful for local processing of messages dropped into a Maildir by an MTA
+    (e.g. postfix delivering DMARC reports). Maildir has no concept of
+    sending — :meth:`send_message` raises :class:`NotImplementedError`.
+    """
+
+    def __init__(
+        self,
+        maildir_path: str,
+        maildir_create: bool = False,
+    ):
+        self._maildir_path = maildir_path
+        self._maildir_create = maildir_create
+
+        # When run as root over a user-owned Maildir, drop privileges to the
+        # Maildir's owner so file creation/locking works correctly. This is
+        # specific to UNIX-like systems with os.getuid()/setuid().
+        getuid = getattr(os, "getuid", None)
+        setuid = getattr(os, "setuid", None)
+        if getuid is not None and setuid is not None:
+            try:
+                maildir_owner = os.stat(maildir_path).st_uid
+            except OSError:
+                maildir_owner = None
+            current_uid = getuid()
+            if maildir_owner is not None and current_uid != maildir_owner:
+                if current_uid == 0:
+                    try:
+                        logger.warning(
+                            "Switching uid to %s to access Maildir", maildir_owner
+                        )
+                        setuid(maildir_owner)
+                    except OSError as e:
+                        logger.warning(
+                            "Failed to switch uid to %s: %s", maildir_owner, e
+                        )
+                else:
+                    logger.warning(
+                        "Runtime uid %s differs from maildir %s owner %s. "
+                        "Access may fail if permissions are insufficient.",
+                        current_uid,
+                        maildir_path,
+                        maildir_owner,
+                    )
+
+        if maildir_create:
+            for subdir in ("cur", "new", "tmp"):
+                os.makedirs(os.path.join(maildir_path, subdir), exist_ok=True)
+        self._client = mailbox.Maildir(maildir_path, create=maildir_create)
+        self._active_folder: mailbox.Maildir = self._client
+        self._subfolder_client: Dict[str, mailbox.Maildir] = {}
+
+    def _get_folder(self, folder_name: str) -> mailbox.Maildir:
+        if folder_name not in self._subfolder_client:
+            self._subfolder_client[folder_name] = self._client.add_folder(folder_name)
+        return self._subfolder_client[folder_name]
+
+    def create_folder(self, folder_name: str) -> None:
+        self._get_folder(folder_name)
+
+    def fetch_messages(self, reports_folder: str, **kwargs: Any) -> list:
+        if reports_folder and reports_folder != "INBOX":
+            self._active_folder = self._get_folder(reports_folder)
+        else:
+            self._active_folder = self._client
+        return list(self._active_folder.keys())
+
+    def fetch_message(self, message_id: Any, **kwargs: Any) -> str:
+        msg = self._active_folder.get(message_id)
+        if msg is None:
+            return ""
+        msg_str = msg.as_string()
+        if kwargs.get("mark_read"):
+            # Maildir spec: a message is "read" once it has been moved out of
+            # new/ into cur/ with the "S" (Seen) flag set in its info field.
+            msg.set_subdir("cur")
+            msg.add_flag("S")
+            self._active_folder[message_id] = msg
+        return msg_str or ""
+
+    def delete_message(self, message_id: Any) -> None:
+        self._active_folder.remove(message_id)
+
+    def move_message(self, message_id: Any, folder_name: str) -> None:
+        message_data = self._active_folder.get(message_id)
+        if message_data is None:
+            return
+        dest = self._get_folder(folder_name)
+        dest.add(message_data)
+        self._active_folder.remove(message_id)
+
+    def keepalive(self) -> None:
+        return
+
+    def watch(
+        self,
+        check_callback: Callable[[MailboxConnection], None],
+        check_timeout: int,
+        config_reloading: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        while True:
+            if config_reloading and config_reloading():
+                return
+            try:
+                check_callback(self)
+            except Exception as e:
+                logger.warning("Maildir init error. %s", e)
+            if config_reloading and config_reloading():
+                return
+            sleep(check_timeout)
+
+    def send_message(self, *args: Any, **kwargs: Any) -> Optional[str]:
+        raise NotImplementedError(
+            "Maildir cannot send mail; use mailsuite.smtp.send_email"
+        )


### PR DESCRIPTION
## Summary

First of two PRs that lift parsedmarc's mailbox abstraction into mailsuite so applications can read/manage mail across multiple providers behind one interface. After both land, parsedmarc consumes mailsuite for this layer instead of maintaining its own copy.

This PR adds:

- `mailsuite.mailbox.MailboxConnection` — ABC with `create_folder`, `fetch_messages`, `fetch_message`, `delete_message`, `move_message`, `keepalive`, `watch`, and a new `send_message` method
- `mailsuite.mailbox.IMAPConnection` — wraps `mailsuite.imap.IMAPClient`, IDLE-based watch loop (lifted from parsedmarc)
- `mailsuite.mailbox.MaildirConnection` — backed by stdlib `mailbox.Maildir` (lifted from parsedmarc)

`send_message()` raises `NotImplementedError` on these two receive-only backends with a pointer to `mailsuite.smtp.send_email` for standalone sending. The Microsoft Graph and Gmail backends — which natively combine receive and send — land in PR2.

The existing `mailsuite.imap`, `mailsuite.smtp`, `mailsuite.utils`, and `mailsuite.dkim` modules are untouched, so existing users (including parsedmarc's current `mailsuite.imap.IMAPClient` consumer) are unaffected.

Class names match parsedmarc's exactly (`MailboxConnection`, `IMAPConnection`, `MaildirConnection`) so the parsedmarc migration is a one-line import change per file.

Version bumped to 1.13.0.

## Test plan

- [x] `mailsuite.mailbox` imports cleanly; `IMAPConnection` and `MaildirConnection` subclass `MailboxConnection`
- [x] Maildir round-trip on a tmpfs: `create_folder`, `fetch_messages`, `fetch_message`, `delete_message`
- [x] `send_message` raises `NotImplementedError` on both backends with a helpful message
- [x] `pyright` (latest) clean on `mailsuite/mailbox/`
- [x] `ruff check` clean
- [ ] Test suite — this package has no tests yet; that's a separate PR after both mailbox PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)