### PR TITLE
Add Microsoft Graph and Gmail mailbox backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
   - `MailboxConnection` ABC with `create_folder`, `fetch_messages`, `fetch_message`, `delete_message`, `move_message`, `keepalive`, `watch`, and `send_message`
   - `IMAPConnection` (built on `mailsuite.imap.IMAPClient`, IDLE-based watch loop)
   - `MaildirConnection` (built on the stdlib `mailbox.Maildir`)
-  - `send_message()` raises `NotImplementedError` on receive-only backends; use `mailsuite.smtp.send_email` for standalone sending. Microsoft Graph and Gmail backends with native `send_message()` support land in a follow-up release.
+  - `MSGraphConnection` (built on `msgraph-sdk`; sends through `/users/{mailbox}/sendMail`). Requires the `mailsuite[msgraph]` extra.
+  - `GmailConnection` (built on `google-api-python-client`; sends through `users.messages.send`). Requires the `mailsuite[gmail]` extra.
+  - Optional cloud backends are loaded lazily via PEP 562 — importing `mailsuite.mailbox` never requires the extras to be installed; referencing the class surfaces a clear `ImportError` if they aren't.
+  - `send_message()` raises `NotImplementedError` on the receive-only IMAP and Maildir backends; use `mailsuite.smtp.send_email` for standalone sending.
 
 ## 1.12.0
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,6 +35,10 @@ mailsuite.mailbox
    :members:
 .. automodule:: mailsuite.mailbox.maildir
    :members:
+.. automodule:: mailsuite.mailbox.graph
+   :members:
+.. automodule:: mailsuite.mailbox.gmail
+   :members:
 ```
 
 mailsuite.utils

--- a/mailsuite/mailbox/__init__.py
+++ b/mailsuite/mailbox/__init__.py
@@ -2,14 +2,39 @@
 
 Lifted from parsedmarc so any application can read/manage mail across IMAP,
 Microsoft Graph, Gmail, or a local Maildir behind a single interface.
+
+The ``MSGraphConnection`` and ``GmailConnection`` backends require optional
+extras (``mailsuite[msgraph]`` and ``mailsuite[gmail]``). They are loaded
+lazily — importing this package never requires those extras to be installed,
+but referencing the class will surface a clear error if they aren't.
 """
+
+from typing import TYPE_CHECKING
 
 from mailsuite.mailbox.base import MailboxConnection
 from mailsuite.mailbox.imap import IMAPConnection
 from mailsuite.mailbox.maildir import MaildirConnection
 
+if TYPE_CHECKING:
+    from mailsuite.mailbox.gmail import GmailConnection
+    from mailsuite.mailbox.graph import MSGraphConnection
+
 __all__ = [
     "MailboxConnection",
     "IMAPConnection",
     "MaildirConnection",
+    "MSGraphConnection",
+    "GmailConnection",
 ]
+
+
+def __getattr__(name: str):
+    if name == "MSGraphConnection":
+        from mailsuite.mailbox.graph import MSGraphConnection
+
+        return MSGraphConnection
+    if name == "GmailConnection":
+        from mailsuite.mailbox.gmail import GmailConnection
+
+        return GmailConnection
+    raise AttributeError(f"module 'mailsuite.mailbox' has no attribute {name!r}")

--- a/mailsuite/mailbox/gmail.py
+++ b/mailsuite/mailbox/gmail.py
@@ -1,0 +1,250 @@
+"""Gmail mailbox backend"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from functools import lru_cache
+from pathlib import Path
+from time import sleep
+from typing import Any, Callable, List, Optional, Tuple
+
+from mailsuite.mailbox.base import MailboxConnection
+from mailsuite.utils import create_email
+
+try:
+    from google.auth.transport.requests import Request
+    from google.oauth2 import service_account
+    from google.oauth2.credentials import Credentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    from googleapiclient.discovery import build
+    from googleapiclient.errors import HttpError
+except ImportError as e:
+    raise ImportError(
+        "GmailConnection requires the 'gmail' extra: pip install mailsuite[gmail]"
+    ) from e
+
+logger = logging.getLogger(__name__)
+
+
+def _get_creds(
+    token_file: str,
+    credentials_file: str,
+    scopes: List[str],
+    oauth2_port: int,
+    auth_mode: str = "installed_app",
+    service_account_user: Optional[str] = None,
+):
+    normalized_auth_mode = (auth_mode or "installed_app").strip().lower()
+    if normalized_auth_mode == "service_account":
+        creds = service_account.Credentials.from_service_account_file(
+            credentials_file,
+            scopes=scopes,
+        )
+        if service_account_user:
+            creds = creds.with_subject(service_account_user)
+        return creds
+    if normalized_auth_mode != "installed_app":
+        raise ValueError(
+            f"Unsupported Gmail auth_mode '{auth_mode}'. "
+            "Expected 'installed_app' or 'service_account'."
+        )
+
+    creds = None
+    if Path(token_file).exists():
+        creds = Credentials.from_authorized_user_file(token_file, scopes)
+
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(credentials_file, scopes)
+            creds = flow.run_local_server(open_browser=False, oauth2_port=oauth2_port)
+        Path(token_file).parent.mkdir(parents=True, exist_ok=True)
+        with Path(token_file).open("w") as token:
+            token.write(creds.to_json())
+    return creds
+
+
+class GmailConnection(MailboxConnection):
+    """
+    A :class:`MailboxConnection` backed by the Gmail API
+
+    Sends mail through ``users.messages.send`` with the message built by
+    :func:`mailsuite.utils.create_email`. Sending requires a scope that
+    includes the send permission (``gmail.send``,
+    ``gmail.modify``, or full ``mail.google.com``).
+
+    Requires the ``gmail`` extra::
+
+        pip install mailsuite[gmail]
+    """
+
+    def __init__(
+        self,
+        token_file: str,
+        credentials_file: str,
+        scopes: List[str],
+        include_spam_trash: bool,
+        reports_folder: str,
+        oauth2_port: int,
+        paginate_messages: bool,
+        auth_mode: str = "installed_app",
+        service_account_user: Optional[str] = None,
+    ):
+        creds = _get_creds(
+            token_file,
+            credentials_file,
+            scopes,
+            oauth2_port,
+            auth_mode=auth_mode,
+            service_account_user=service_account_user,
+        )
+        self.service = build("gmail", "v1", credentials=creds)
+        self.include_spam_trash = include_spam_trash
+        self.reports_label_id = self._find_label_id_for_label(reports_folder)
+        self.paginate_messages = paginate_messages
+
+    def create_folder(self, folder_name: str) -> None:
+        # Gmail uses labels; "Archive" isn't a real Gmail concept
+        if folder_name == "Archive":
+            return
+
+        logger.debug("Creating label %s", folder_name)
+        request_body = {"name": folder_name, "messageListVisibility": "show"}
+        try:
+            self.service.users().labels().create(
+                userId="me", body=request_body
+            ).execute()
+        except HttpError as e:
+            if e.status_code == 409:
+                logger.debug("Folder %s already exists, skipping creation", folder_name)
+            else:
+                raise
+
+    def _fetch_all_message_ids(
+        self,
+        reports_label_id: str,
+        page_token: Optional[str] = None,
+        since: Optional[str] = None,
+    ):
+        if since:
+            results = (
+                self.service.users()
+                .messages()
+                .list(
+                    userId="me",
+                    includeSpamTrash=self.include_spam_trash,
+                    labelIds=[reports_label_id],
+                    pageToken=page_token,
+                    q=f"after:{since}",
+                )
+                .execute()
+            )
+        else:
+            results = (
+                self.service.users()
+                .messages()
+                .list(
+                    userId="me",
+                    includeSpamTrash=self.include_spam_trash,
+                    labelIds=[reports_label_id],
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+        for message in results.get("messages", []):
+            yield message["id"]
+
+        if "nextPageToken" in results and self.paginate_messages:
+            yield from self._fetch_all_message_ids(
+                reports_label_id, results["nextPageToken"]
+            )
+
+    def fetch_messages(self, reports_folder: str, **kwargs: Any) -> List[str]:
+        reports_label_id = self._find_label_id_for_label(reports_folder)
+        since = kwargs.get("since")
+        if since:
+            return list(self._fetch_all_message_ids(reports_label_id, since=since))
+        return list(self._fetch_all_message_ids(reports_label_id))
+
+    def fetch_message(self, message_id: Any, **kwargs: Any) -> str:
+        msg = (
+            self.service.users()
+            .messages()
+            .get(userId="me", id=message_id, format="raw")
+            .execute()
+        )
+        return base64.urlsafe_b64decode(msg["raw"]).decode(errors="replace")
+
+    def delete_message(self, message_id: Any) -> None:
+        self.service.users().messages().delete(userId="me", id=message_id).execute()
+
+    def move_message(self, message_id: Any, folder_name: str) -> None:
+        label_id = self._find_label_id_for_label(folder_name)
+        logger.debug("Moving message UID %s to %s", message_id, folder_name)
+        request_body = {
+            "addLabelIds": [label_id],
+            "removeLabelIds": [self.reports_label_id],
+        }
+        self.service.users().messages().modify(
+            userId="me", id=message_id, body=request_body
+        ).execute()
+
+    def keepalive(self) -> None:
+        return
+
+    def watch(
+        self,
+        check_callback: Callable[[MailboxConnection], None],
+        check_timeout: int,
+        config_reloading: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        """Poll the mailbox at ``check_timeout``-second intervals"""
+        while True:
+            if config_reloading and config_reloading():
+                return
+            sleep(check_timeout)
+            if config_reloading and config_reloading():
+                return
+            check_callback(self)
+
+    def send_message(
+        self,
+        message_from: str,
+        message_to: Optional[List[str]] = None,
+        message_cc: Optional[List[str]] = None,
+        message_bcc: Optional[List[str]] = None,
+        subject: Optional[str] = None,
+        message_headers: Optional[dict] = None,
+        attachments: Optional[List[Tuple[str, bytes]]] = None,
+        plain_message: Optional[str] = None,
+        html_message: Optional[str] = None,
+    ) -> Optional[str]:
+        raw = create_email(
+            message_from=message_from,
+            message_to=message_to,
+            message_cc=message_cc,
+            subject=subject,
+            message_headers=message_headers,
+            attachments=attachments,
+            plain_message=plain_message,
+            html_message=html_message,
+        )
+        encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+        body: dict = {"raw": encoded}
+        sent = (
+            self.service.users()
+            .messages()
+            .send(userId="me", body=body)
+            .execute()
+        )
+        return sent.get("id")
+
+    @lru_cache(maxsize=10)
+    def _find_label_id_for_label(self, label_name: str) -> str:
+        results = self.service.users().labels().list(userId="me").execute()
+        for label in results.get("labels", []):
+            if label_name == label["id"] or label_name == label["name"]:
+                return label["id"]
+        return ""

--- a/mailsuite/mailbox/graph.py
+++ b/mailsuite/mailbox/graph.py
@@ -1,0 +1,474 @@
+"""Microsoft Graph mailbox backend"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from enum import Enum
+from functools import lru_cache
+from pathlib import Path
+from time import sleep
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+from mailsuite.mailbox.base import MailboxConnection
+
+try:
+    from azure.identity import (
+        AuthenticationRecord,
+        CertificateCredential,
+        ClientSecretCredential,
+        DeviceCodeCredential,
+        TokenCachePersistenceOptions,
+        UsernamePasswordCredential,
+    )
+    from msgraph.graph_service_client import GraphServiceClient
+    from msgraph.generated.models.body_type import BodyType
+    from msgraph.generated.models.email_address import EmailAddress
+    from msgraph.generated.models.file_attachment import FileAttachment
+    from msgraph.generated.models.item_body import ItemBody
+    from msgraph.generated.models.mail_folder import MailFolder
+    from msgraph.generated.models.message import Message
+    from msgraph.generated.models.recipient import Recipient
+    from msgraph.generated.users.item.mail_folders.item.child_folders.child_folders_request_builder import (  # noqa: E501
+        ChildFoldersRequestBuilder,
+    )
+    from msgraph.generated.users.item.mail_folders.mail_folders_request_builder import (
+        MailFoldersRequestBuilder,
+    )
+    from msgraph.generated.users.item.mail_folders.item.messages.messages_request_builder import (  # noqa: E501
+        MessagesRequestBuilder,
+    )
+    from msgraph.generated.users.item.messages.item.move.move_post_request_body import (
+        MovePostRequestBody,
+    )
+    from msgraph.generated.users.item.send_mail.send_mail_post_request_body import (
+        SendMailPostRequestBody,
+    )
+except ImportError as e:
+    raise ImportError(
+        "MSGraphConnection requires the 'msgraph' extra: "
+        "pip install mailsuite[msgraph]"
+    ) from e
+
+logger = logging.getLogger(__name__)
+
+
+class AuthMethod(Enum):
+    DeviceCode = 1
+    UsernamePassword = 2
+    ClientSecret = 3
+    Certificate = 4
+
+
+def _get_cache_args(token_path: Path, allow_unencrypted_storage: bool) -> dict:
+    cache_args: dict = {
+        "cache_persistence_options": TokenCachePersistenceOptions(
+            name="mailsuite", allow_unencrypted_storage=allow_unencrypted_storage
+        )
+    }
+    auth_record = _load_token(token_path)
+    if auth_record:
+        cache_args["authentication_record"] = AuthenticationRecord.deserialize(
+            auth_record
+        )
+    return cache_args
+
+
+def _load_token(token_path: Path) -> Optional[str]:
+    if not token_path.exists():
+        return None
+    with token_path.open() as token_file:
+        return token_file.read()
+
+
+def _cache_auth_record(record: AuthenticationRecord, token_path: Path) -> None:
+    token = record.serialize()
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    with token_path.open("w") as token_file:
+        token_file.write(token)
+
+
+def _generate_credential(auth_method: str, token_path: Path, **kwargs):
+    if auth_method == AuthMethod.DeviceCode.name:
+        return DeviceCodeCredential(
+            client_id=kwargs["client_id"],
+            disable_automatic_authentication=True,
+            tenant_id=kwargs["tenant_id"],
+            **_get_cache_args(
+                token_path,
+                allow_unencrypted_storage=kwargs["allow_unencrypted_storage"],
+            ),
+        )
+    if auth_method == AuthMethod.UsernamePassword.name:
+        return UsernamePasswordCredential(
+            client_id=kwargs["client_id"],
+            client_credential=kwargs["client_secret"],
+            disable_automatic_authentication=True,
+            username=kwargs["username"],
+            password=kwargs["password"],
+            **_get_cache_args(
+                token_path,
+                allow_unencrypted_storage=kwargs["allow_unencrypted_storage"],
+            ),
+        )
+    if auth_method == AuthMethod.ClientSecret.name:
+        return ClientSecretCredential(
+            client_id=kwargs["client_id"],
+            tenant_id=kwargs["tenant_id"],
+            client_secret=kwargs["client_secret"],
+        )
+    if auth_method == AuthMethod.Certificate.name:
+        cert_path = kwargs.get("certificate_path")
+        if not cert_path:
+            raise ValueError(
+                "certificate_path is required when auth_method is 'Certificate'"
+            )
+        return CertificateCredential(
+            client_id=kwargs["client_id"],
+            tenant_id=kwargs["tenant_id"],
+            certificate_path=cert_path,
+            password=kwargs.get("certificate_password"),
+        )
+    raise RuntimeError(f"Auth method {auth_method} not found")
+
+
+def _run(coro):
+    """Run a coroutine to completion. Refuses to nest in a running loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    raise RuntimeError(
+        "MSGraphConnection cannot be called from inside a running event loop. "
+        "Use msgraph.GraphServiceClient directly from async code."
+    )
+
+
+class MSGraphConnection(MailboxConnection):
+    """
+    A :class:`MailboxConnection` backed by Microsoft Graph
+
+    Supports DeviceCode, UsernamePassword, ClientSecret, and Certificate
+    auth via :mod:`azure.identity`. Send mail goes through
+    ``/users/{mailbox}/sendMail`` with a structured ``Message`` body
+    (Graph automatically saves a copy to Sent Items).
+
+    Requires the ``msgraph`` extra::
+
+        pip install mailsuite[msgraph]
+    """
+
+    _WELL_KNOWN_FOLDERS = {
+        "inbox": "inbox",
+        "archive": "archive",
+        "drafts": "drafts",
+        "sentitems": "sentitems",
+        "deleteditems": "deleteditems",
+        "junkemail": "junkemail",
+    }
+
+    def __init__(
+        self,
+        auth_method: str,
+        mailbox: str,
+        client_id: str,
+        client_secret: Optional[str],
+        username: Optional[str],
+        password: Optional[str],
+        tenant_id: str,
+        token_file: str,
+        allow_unencrypted_storage: bool,
+        certificate_path: Optional[str] = None,
+        certificate_password: Optional[Union[str, bytes]] = None,
+    ):
+        token_path = Path(token_file)
+        credential = _generate_credential(
+            auth_method,
+            client_id=client_id,
+            client_secret=client_secret,
+            certificate_path=certificate_path,
+            certificate_password=certificate_password,
+            username=username,
+            password=password,
+            tenant_id=tenant_id,
+            token_path=token_path,
+            allow_unencrypted_storage=allow_unencrypted_storage,
+        )
+
+        scopes: Optional[List[str]] = None
+        if not isinstance(credential, (ClientSecretCredential, CertificateCredential)):
+            scopes = ["Mail.ReadWrite"]
+            # Detect if mailbox is shared
+            if mailbox and username and username != mailbox:
+                scopes = ["Mail.ReadWrite.Shared"]
+            auth_record = credential.authenticate(scopes=scopes)
+            _cache_auth_record(auth_record, token_path)
+
+        self._client = GraphServiceClient(credentials=credential, scopes=scopes)
+        self.mailbox_name = mailbox
+
+    # — folder management —
+
+    def create_folder(self, folder_name: str) -> None:
+        path_parts = folder_name.split("/")
+        parent_folder_id: Optional[str] = None
+        if len(path_parts) > 1:
+            for folder in path_parts[:-1]:
+                parent_folder_id = self._find_folder_id_with_parent(
+                    folder, parent_folder_id
+                )
+            folder_name = path_parts[-1]
+
+        body = MailFolder(display_name=folder_name)
+        try:
+            if parent_folder_id is None:
+                _run(
+                    self._client.users.by_user_id(
+                        self.mailbox_name
+                    ).mail_folders.post(body)
+                )
+            else:
+                _run(
+                    self._client.users.by_user_id(self.mailbox_name)
+                    .mail_folders.by_mail_folder_id(parent_folder_id)
+                    .child_folders.post(body)
+                )
+            logger.debug("Created folder %s", folder_name)
+        except Exception as e:
+            # 409 / "already exists" is normal — surface other errors
+            if "already exists" in str(e).lower() or "ErrorFolderExists" in str(e):
+                logger.debug("Folder %s already exists, skipping", folder_name)
+                return
+            raise
+
+    # — message reading —
+
+    def fetch_messages(self, reports_folder: str, **kwargs: Any) -> List[str]:
+        folder_id = self._find_folder_id_from_folder_path(reports_folder)
+        since = kwargs.get("since") or None
+        batch_size = kwargs.get("batch_size") or 0
+        return _run(self._fetch_messages_async(folder_id, batch_size, since))
+
+    async def _fetch_messages_async(
+        self, folder_id: str, batch_size: int, since: Optional[str]
+    ) -> List[str]:
+        query = MessagesRequestBuilder.MessagesRequestBuilderGetQueryParameters(
+            select=["id"],
+            top=batch_size if batch_size > 0 else 100,
+        )
+        if since:
+            query.filter = f"receivedDateTime ge {since}"
+        config = (
+            MessagesRequestBuilder.MessagesRequestBuilderGetRequestConfiguration(
+                query_parameters=query
+            )
+        )
+        page = (
+            await self._client.users.by_user_id(self.mailbox_name)
+            .mail_folders.by_mail_folder_id(folder_id)
+            .messages.get(request_configuration=config)
+        )
+        ids: List[str] = []
+        while page is not None and page.value:
+            ids.extend(m.id for m in page.value if m.id)
+            next_link = page.odata_next_link
+            keep_going = since is not None or batch_size == 0 or len(ids) < batch_size
+            if not next_link or not keep_going:
+                break
+            page = (
+                await self._client.users.by_user_id(self.mailbox_name)
+                .mail_folders.by_mail_folder_id(folder_id)
+                .messages.with_url(next_link)
+                .get()
+            )
+        return ids
+
+    def fetch_message(self, message_id: Any, **kwargs: Any) -> str:
+        raw = _run(
+            self._client.users.by_user_id(self.mailbox_name)
+            .messages.by_message_id(str(message_id))
+            .content.get()
+        )
+        if kwargs.get("mark_read"):
+            self.mark_message_read(str(message_id))
+        if isinstance(raw, bytes):
+            return raw.decode("utf-8", errors="replace")
+        return raw or ""
+
+    def mark_message_read(self, message_id: str) -> None:
+        _run(
+            self._client.users.by_user_id(self.mailbox_name)
+            .messages.by_message_id(message_id)
+            .patch(Message(is_read=True))
+        )
+
+    def delete_message(self, message_id: Any) -> None:
+        _run(
+            self._client.users.by_user_id(self.mailbox_name)
+            .messages.by_message_id(str(message_id))
+            .delete()
+        )
+
+    def move_message(self, message_id: Any, folder_name: str) -> None:
+        folder_id = self._find_folder_id_from_folder_path(folder_name)
+        body = MovePostRequestBody(destination_id=folder_id)
+        _run(
+            self._client.users.by_user_id(self.mailbox_name)
+            .messages.by_message_id(str(message_id))
+            .move.post(body)
+        )
+
+    def keepalive(self) -> None:
+        # Graph uses bearer tokens; nothing to ping
+        return
+
+    def watch(
+        self,
+        check_callback: Callable[[MailboxConnection], None],
+        check_timeout: int,
+        config_reloading: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        """Poll the mailbox at ``check_timeout``-second intervals"""
+        while True:
+            if config_reloading and config_reloading():
+                return
+            sleep(check_timeout)
+            if config_reloading and config_reloading():
+                return
+            check_callback(self)
+
+    # — sending —
+
+    def send_message(
+        self,
+        message_from: str,
+        message_to: Optional[List[str]] = None,
+        message_cc: Optional[List[str]] = None,
+        message_bcc: Optional[List[str]] = None,
+        subject: Optional[str] = None,
+        message_headers: Optional[dict] = None,
+        attachments: Optional[List[Tuple[str, bytes]]] = None,
+        plain_message: Optional[str] = None,
+        html_message: Optional[str] = None,
+    ) -> Optional[str]:
+        # Graph derives ``From`` from the authenticated mailbox; ``message_from``
+        # and ``message_headers`` are accepted for API parity but not used by
+        # the structured /sendMail endpoint.
+        del message_from, message_headers
+
+        if html_message is not None:
+            body = ItemBody(content_type=BodyType.Html, content=html_message)
+        else:
+            body = ItemBody(content_type=BodyType.Text, content=plain_message or "")
+
+        def _to_recipients(addrs: Optional[List[str]]) -> Optional[List[Recipient]]:
+            if not addrs:
+                return None
+            return [
+                Recipient(email_address=EmailAddress(address=addr)) for addr in addrs
+            ]
+
+        graph_attachments: Optional[List[Any]] = None
+        if attachments:
+            graph_attachments = [
+                FileAttachment(
+                    odata_type="#microsoft.graph.fileAttachment",
+                    name=filename,
+                    content_bytes=payload,
+                )
+                for filename, payload in attachments
+            ]
+
+        message = Message(
+            subject=subject,
+            body=body,
+            to_recipients=_to_recipients(message_to),
+            cc_recipients=_to_recipients(message_cc),
+            bcc_recipients=_to_recipients(message_bcc),
+            attachments=graph_attachments,
+        )
+        request = SendMailPostRequestBody(message=message, save_to_sent_items=True)
+        _run(
+            self._client.users.by_user_id(self.mailbox_name).send_mail.post(request)
+        )
+        return None
+
+    # — folder ID resolution —
+
+    @lru_cache(maxsize=10)
+    def _find_folder_id_from_folder_path(self, folder_name: str) -> str:
+        path_parts = folder_name.split("/")
+        parent_folder_id: Optional[str] = None
+        if len(path_parts) > 1:
+            for folder in path_parts[:-1]:
+                parent_folder_id = self._find_folder_id_with_parent(
+                    folder, parent_folder_id
+                )
+            return self._find_folder_id_with_parent(path_parts[-1], parent_folder_id)
+        return self._find_folder_id_with_parent(folder_name, None)
+
+    def _get_well_known_folder_id(self, folder_name: str) -> Optional[str]:
+        folder_key = folder_name.lower().replace(" ", "").replace("-", "")
+        alias = self._WELL_KNOWN_FOLDERS.get(folder_key)
+        if alias is None:
+            return None
+        try:
+            folder = _run(
+                self._client.users.by_user_id(self.mailbox_name)
+                .mail_folders.by_mail_folder_id(alias)
+                .get()
+            )
+        except Exception:
+            return None
+        return folder.id if folder else None
+
+    def _find_folder_id_with_parent(
+        self, folder_name: str, parent_folder_id: Optional[str]
+    ) -> str:
+        try:
+            folders = self._list_folders_filtered(folder_name, parent_folder_id)
+        except Exception as e:
+            if parent_folder_id is None:
+                well_known = self._get_well_known_folder_id(folder_name)
+                if well_known:
+                    return well_known
+            raise RuntimeError(f"Failed to list folders: {e}") from e
+
+        for folder in folders:
+            if folder.display_name == folder_name and folder.id:
+                return folder.id
+
+        if parent_folder_id is None:
+            well_known = self._get_well_known_folder_id(folder_name)
+            if well_known:
+                return well_known
+        raise RuntimeError(f"folder {folder_name} not found")
+
+    def _list_folders_filtered(
+        self, folder_name: str, parent_folder_id: Optional[str]
+    ) -> List[MailFolder]:
+        if parent_folder_id is None:
+            query = MailFoldersRequestBuilder.MailFoldersRequestBuilderGetQueryParameters(
+                filter=f"displayName eq '{folder_name}'"
+            )
+            config = MailFoldersRequestBuilder.MailFoldersRequestBuilderGetRequestConfiguration(
+                query_parameters=query
+            )
+            page = _run(
+                self._client.users.by_user_id(
+                    self.mailbox_name
+                ).mail_folders.get(request_configuration=config)
+            )
+        else:
+            child_query = ChildFoldersRequestBuilder.ChildFoldersRequestBuilderGetQueryParameters(
+                filter=f"displayName eq '{folder_name}'"
+            )
+            child_config = ChildFoldersRequestBuilder.ChildFoldersRequestBuilderGetRequestConfiguration(
+                query_parameters=child_query
+            )
+            page = _run(
+                self._client.users.by_user_id(self.mailbox_name)
+                .mail_folders.by_mail_folder_id(parent_folder_id)
+                .child_folders.get(request_configuration=child_config)
+            )
+        return list(page.value or []) if page is not None else []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,20 @@ dynamic = [
     "version",
 ]
 
+[project.optional-dependencies]
+msgraph = [
+    "azure-identity>=1.15.0",
+    "msgraph-sdk>=1.0.0",
+]
+gmail = [
+    "google-api-python-client>=2.0.0",
+    "google-auth>=2.0.0",
+    "google-auth-oauthlib>=1.0.0",
+]
+all = [
+    "mailsuite[msgraph,gmail]",
+]
+
 [project.urls]
 Homepage = "https://github.com/seanthegeek/mailsuite/"
 Documentation = "https://seanthegeek.github.io/mailsuite/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,11 @@ publicsuffix2>=2.20190812
 expiringdict==1.2.2
 dkimpy>=1.1.0
 cryptography>=41.0.0
+msgraph-sdk>=1.0.0
+azure-identity>=1.15.0
+google-api-python-client>=2.0.0
+google-auth>=2.0.0
+google-auth-oauthlib>=1.0.0
 nose
 pygments
 ruff


### PR DESCRIPTION
## Summary

PR2 of two. Adds the cloud-native mailbox backends — `MSGraphConnection` and `GmailConnection` — with native `send_message` support, completing the goal that `mailsuite.mailbox` covers the full mailbox lifecycle (send + receive + watch) for every supported provider.

> Stacks on #18 — review/merge that one first.

### What lands

- **`mailsuite.mailbox.MSGraphConnection`** built on the modern `msgraph-sdk` (Kiota). The `msgraph-core==0.2.2` version parsedmarc currently pins is effectively abandoned by Microsoft, so this PR migrates to the supported library; parsedmarc gets the migration for free when it consumes mailsuite. Sends through `/users/{mailbox}/sendMail` with a structured `Message` body (Graph automatically saves to Sent Items).
- **`mailsuite.mailbox.GmailConnection`** lifted from parsedmarc with sending added via `users.messages.send` (built on top of `mailsuite.utils.create_email`). Supports both installed-app OAuth and service-account auth.
- **Optional extras** in `pyproject.toml`:
  - `mailsuite[msgraph]` → `azure-identity>=1.15.0`, `msgraph-sdk>=1.0.0`
  - `mailsuite[gmail]` → `google-api-python-client>=2.0.0`, `google-auth>=2.0.0`, `google-auth-oauthlib>=1.0.0`
  - `mailsuite[all]` → both
- **Lazy loading via PEP 562 `__getattr__`** on the `mailsuite.mailbox` package — importing the package never requires the extras. The first reference to `MSGraphConnection` or `GmailConnection` triggers the submodule import, which raises a friendly `ImportError` pointing at the right extra if it isn't installed.
- Async wrangling for the SDK lives in a small private `_run` helper that uses `asyncio.run()` per call. Nesting in an existing event loop raises a clear error pointing users at `msgraph.GraphServiceClient` directly.

### Notes

- Sending via Gmail requires a scope that includes send permission (`gmail.send`, `gmail.modify`, or full `mail.google.com`). Documented on the class.
- Sending via Graph derives `From` from the authenticated mailbox; the `message_from` argument is accepted for API parity but ignored by the structured `/sendMail` endpoint.
- DKIM signing makes no sense via Graph or Gmail — both providers sign on your behalf. The `send_message` API doesn't accept DKIM params on those backends; use `mailsuite.smtp.send_email` for cases where you need to control DKIM yourself.

## Test plan

- [x] `import mailsuite.mailbox` succeeds without `[msgraph]`/`[gmail]` extras (verified by hiding `msgraph` from `sys.meta_path` and asserting the friendly `ImportError`)
- [x] `from mailsuite.mailbox import MSGraphConnection` and `GmailConnection` resolve via `__getattr__` and return the right classes
- [x] All four backends subclass `MailboxConnection` and define `send_message`
- [x] `pyright` (latest) clean on `mailsuite/mailbox/`
- [x] `ruff check` clean
- [ ] Live integration tests against Graph and Gmail — out of scope for this PR; this package has no test suite yet (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)