### PR TITLE
Add test suite, CI workflow, and 2.0.0 release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint and type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[msgraph,gmail]"
+          pip install ruff pyright
+
+      - name: ruff
+        run: ruff check mailsuite tests
+
+      - name: pyright
+        env:
+          PYRIGHT_PYTHON_FORCE_VERSION: latest
+        run: pyright mailsuite
+
+  test:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[msgraph,gmail]"
+          pip install pytest pytest-cov
+
+      - name: pytest
+        run: pytest --cov=mailsuite --cov-report=xml --cov-report=term
+
+      - name: Upload coverage
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
   - `MailboxConnection` ABC with `create_folder`, `fetch_messages`, `fetch_message`, `delete_message`, `move_message`, `keepalive`, `watch`, and `send_message`
   - `IMAPConnection` (built on `mailsuite.imap.IMAPClient`, IDLE-based watch loop)
   - `MaildirConnection` (built on the stdlib `mailbox.Maildir`)
-  - `send_message()` raises `NotImplementedError` on receive-only backends; use `mailsuite.smtp.send_email` for standalone sending. Microsoft Graph and Gmail backends with native `send_message()` support land in a follow-up release.
+  - `MSGraphConnection` (built on `msgraph-sdk`; sends through `/users/{mailbox}/sendMail`). Requires the `mailsuite[msgraph]` extra.
+  - `GmailConnection` (built on `google-api-python-client`; sends through `users.messages.send`). Requires the `mailsuite[gmail]` extra.
+  - Optional cloud backends are loaded lazily via PEP 562 — importing `mailsuite.mailbox` never requires the extras to be installed; referencing the class surfaces a clear `ImportError` if they aren't.
+  - `send_message()` raises `NotImplementedError` on the receive-only IMAP and Maildir backends; use `mailsuite.smtp.send_email` for standalone sending.
 
 ## 1.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 1.13.0
+## 2.0.0
 
+- Add a new `mailsuite.dkim` module for DKIM key generation, public key extraction, TXT record generation, email signing, and signature verification
+- `smtp.send_email()` now accepts `dkim_private_key`, `dkim_selector`, `dkim_domain`, and `dkim_additional_headers` parameters for sending DKIM-signed mail
 - Add `mailsuite.mailbox`, a provider-agnostic mailbox abstraction lifted from `parsedmarc`
   - `MailboxConnection` ABC with `create_folder`, `fetch_messages`, `fetch_message`, `delete_message`, `move_message`, `keepalive`, `watch`, and `send_message`
   - `IMAPConnection` (built on `mailsuite.imap.IMAPClient`, IDLE-based watch loop)
@@ -10,11 +12,7 @@
   - `GmailConnection` (built on `google-api-python-client`; sends through `users.messages.send`). Requires the `mailsuite[gmail]` extra.
   - Optional cloud backends are loaded lazily via PEP 562 — importing `mailsuite.mailbox` never requires the extras to be installed; referencing the class surfaces a clear `ImportError` if they aren't.
   - `send_message()` raises `NotImplementedError` on the receive-only IMAP and Maildir backends; use `mailsuite.smtp.send_email` for standalone sending.
-
-## 1.12.0
-
-- Add a new `mailsuite.dkim` module for DKIM key generation, public key extraction, TXT record generation, email signing, and signature verification
-- `smtp.send_email()` now accepts `dkim_private_key`, `dkim_selector`, `dkim_domain`, and `dkim_additional_headers` parameters for sending DKIM-signed mail
+- Add a comprehensive `pytest` test suite covering all modules, plus a GitHub Actions CI workflow that runs `ruff`, `pyright`, and `pytest` (with coverage) across supported Python versions
 
 ## 1.11.2
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,6 +35,10 @@ mailsuite.mailbox
    :members:
 .. automodule:: mailsuite.mailbox.maildir
    :members:
+.. automodule:: mailsuite.mailbox.graph
+   :members:
+.. automodule:: mailsuite.mailbox.gmail
+   :members:
 ```
 
 mailsuite.utils

--- a/mailsuite/__init__.py
+++ b/mailsuite/__init__.py
@@ -1,3 +1,3 @@
 """A Python package to simplify receiving, parsing, and sending email"""
 
-__version__ = "1.13.0"
+__version__ = "2.0.0"

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -346,11 +346,13 @@ class IMAPClient(imapclient.IMAPClient):
             silent: Do it silently
             _attempt: The attempt number
         """
-        logger.info(
-            "Deleting message UID(s) {0}".format(",".join(str(uid) for uid in messages))  # pyright: ignore[reportGeneralTypeIssues]
-        )
         if type(messages) is str or type(messages) is int:
             messages = [int(messages)]
+        logger.info(
+            "Deleting message UID(s) {0}".format(
+                ",".join(str(uid) for uid in messages)  # pyright: ignore[reportGeneralTypeIssues]
+            )
+        )
         try:
             imapclient.IMAPClient.delete_messages(self, messages, silent=silent)
             imapclient.IMAPClient.expunge(self, messages)

--- a/mailsuite/mailbox/__init__.py
+++ b/mailsuite/mailbox/__init__.py
@@ -2,14 +2,39 @@
 
 Lifted from parsedmarc so any application can read/manage mail across IMAP,
 Microsoft Graph, Gmail, or a local Maildir behind a single interface.
+
+The ``MSGraphConnection`` and ``GmailConnection`` backends require optional
+extras (``mailsuite[msgraph]`` and ``mailsuite[gmail]``). They are loaded
+lazily — importing this package never requires those extras to be installed,
+but referencing the class will surface a clear error if they aren't.
 """
+
+from typing import TYPE_CHECKING
 
 from mailsuite.mailbox.base import MailboxConnection
 from mailsuite.mailbox.imap import IMAPConnection
 from mailsuite.mailbox.maildir import MaildirConnection
 
+if TYPE_CHECKING:
+    from mailsuite.mailbox.gmail import GmailConnection
+    from mailsuite.mailbox.graph import MSGraphConnection
+
 __all__ = [
     "MailboxConnection",
     "IMAPConnection",
     "MaildirConnection",
+    "MSGraphConnection",
+    "GmailConnection",
 ]
+
+
+def __getattr__(name: str):
+    if name == "MSGraphConnection":
+        from mailsuite.mailbox.graph import MSGraphConnection
+
+        return MSGraphConnection
+    if name == "GmailConnection":
+        from mailsuite.mailbox.gmail import GmailConnection
+
+        return GmailConnection
+    raise AttributeError(f"module 'mailsuite.mailbox' has no attribute {name!r}")

--- a/mailsuite/mailbox/gmail.py
+++ b/mailsuite/mailbox/gmail.py
@@ -1,0 +1,250 @@
+"""Gmail mailbox backend"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from functools import lru_cache
+from pathlib import Path
+from time import sleep
+from typing import Any, Callable, List, Optional, Tuple
+
+from mailsuite.mailbox.base import MailboxConnection
+from mailsuite.utils import create_email
+
+try:
+    from google.auth.transport.requests import Request
+    from google.oauth2 import service_account
+    from google.oauth2.credentials import Credentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    from googleapiclient.discovery import build
+    from googleapiclient.errors import HttpError
+except ImportError as e:
+    raise ImportError(
+        "GmailConnection requires the 'gmail' extra: pip install mailsuite[gmail]"
+    ) from e
+
+logger = logging.getLogger(__name__)
+
+
+def _get_creds(
+    token_file: str,
+    credentials_file: str,
+    scopes: List[str],
+    oauth2_port: int,
+    auth_mode: str = "installed_app",
+    service_account_user: Optional[str] = None,
+):
+    normalized_auth_mode = (auth_mode or "installed_app").strip().lower()
+    if normalized_auth_mode == "service_account":
+        creds = service_account.Credentials.from_service_account_file(
+            credentials_file,
+            scopes=scopes,
+        )
+        if service_account_user:
+            creds = creds.with_subject(service_account_user)
+        return creds
+    if normalized_auth_mode != "installed_app":
+        raise ValueError(
+            f"Unsupported Gmail auth_mode '{auth_mode}'. "
+            "Expected 'installed_app' or 'service_account'."
+        )
+
+    creds = None
+    if Path(token_file).exists():
+        creds = Credentials.from_authorized_user_file(token_file, scopes)
+
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(credentials_file, scopes)
+            creds = flow.run_local_server(open_browser=False, oauth2_port=oauth2_port)
+        Path(token_file).parent.mkdir(parents=True, exist_ok=True)
+        with Path(token_file).open("w") as token:
+            token.write(creds.to_json())
+    return creds
+
+
+class GmailConnection(MailboxConnection):
+    """
+    A :class:`MailboxConnection` backed by the Gmail API
+
+    Sends mail through ``users.messages.send`` with the message built by
+    :func:`mailsuite.utils.create_email`. Sending requires a scope that
+    includes the send permission (``gmail.send``,
+    ``gmail.modify``, or full ``mail.google.com``).
+
+    Requires the ``gmail`` extra::
+
+        pip install mailsuite[gmail]
+    """
+
+    def __init__(
+        self,
+        token_file: str,
+        credentials_file: str,
+        scopes: List[str],
+        include_spam_trash: bool,
+        reports_folder: str,
+        oauth2_port: int,
+        paginate_messages: bool,
+        auth_mode: str = "installed_app",
+        service_account_user: Optional[str] = None,
+    ):
+        creds = _get_creds(
+            token_file,
+            credentials_file,
+            scopes,
+            oauth2_port,
+            auth_mode=auth_mode,
+            service_account_user=service_account_user,
+        )
+        self.service = build("gmail", "v1", credentials=creds)
+        self.include_spam_trash = include_spam_trash
+        self.reports_label_id = self._find_label_id_for_label(reports_folder)
+        self.paginate_messages = paginate_messages
+
+    def create_folder(self, folder_name: str) -> None:
+        # Gmail uses labels; "Archive" isn't a real Gmail concept
+        if folder_name == "Archive":
+            return
+
+        logger.debug("Creating label %s", folder_name)
+        request_body = {"name": folder_name, "messageListVisibility": "show"}
+        try:
+            self.service.users().labels().create(
+                userId="me", body=request_body
+            ).execute()
+        except HttpError as e:
+            if e.status_code == 409:
+                logger.debug("Folder %s already exists, skipping creation", folder_name)
+            else:
+                raise
+
+    def _fetch_all_message_ids(
+        self,
+        reports_label_id: str,
+        page_token: Optional[str] = None,
+        since: Optional[str] = None,
+    ):
+        if since:
+            results = (
+                self.service.users()
+                .messages()
+                .list(
+                    userId="me",
+                    includeSpamTrash=self.include_spam_trash,
+                    labelIds=[reports_label_id],
+                    pageToken=page_token,
+                    q=f"after:{since}",
+                )
+                .execute()
+            )
+        else:
+            results = (
+                self.service.users()
+                .messages()
+                .list(
+                    userId="me",
+                    includeSpamTrash=self.include_spam_trash,
+                    labelIds=[reports_label_id],
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+        for message in results.get("messages", []):
+            yield message["id"]
+
+        if "nextPageToken" in results and self.paginate_messages:
+            yield from self._fetch_all_message_ids(
+                reports_label_id, results["nextPageToken"]
+            )
+
+    def fetch_messages(self, reports_folder: str, **kwargs: Any) -> List[str]:
+        reports_label_id = self._find_label_id_for_label(reports_folder)
+        since = kwargs.get("since")
+        if since:
+            return list(self._fetch_all_message_ids(reports_label_id, since=since))
+        return list(self._fetch_all_message_ids(reports_label_id))
+
+    def fetch_message(self, message_id: Any, **kwargs: Any) -> str:
+        msg = (
+            self.service.users()
+            .messages()
+            .get(userId="me", id=message_id, format="raw")
+            .execute()
+        )
+        return base64.urlsafe_b64decode(msg["raw"]).decode(errors="replace")
+
+    def delete_message(self, message_id: Any) -> None:
+        self.service.users().messages().delete(userId="me", id=message_id).execute()
+
+    def move_message(self, message_id: Any, folder_name: str) -> None:
+        label_id = self._find_label_id_for_label(folder_name)
+        logger.debug("Moving message UID %s to %s", message_id, folder_name)
+        request_body = {
+            "addLabelIds": [label_id],
+            "removeLabelIds": [self.reports_label_id],
+        }
+        self.service.users().messages().modify(
+            userId="me", id=message_id, body=request_body
+        ).execute()
+
+    def keepalive(self) -> None:
+        return
+
+    def watch(
+        self,
+        check_callback: Callable[[MailboxConnection], None],
+        check_timeout: int,
+        config_reloading: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        """Poll the mailbox at ``check_timeout``-second intervals"""
+        while True:
+            if config_reloading and config_reloading():
+                return
+            sleep(check_timeout)
+            if config_reloading and config_reloading():
+                return
+            check_callback(self)
+
+    def send_message(
+        self,
+        message_from: str,
+        message_to: Optional[List[str]] = None,
+        message_cc: Optional[List[str]] = None,
+        message_bcc: Optional[List[str]] = None,
+        subject: Optional[str] = None,
+        message_headers: Optional[dict] = None,
+        attachments: Optional[List[Tuple[str, bytes]]] = None,
+        plain_message: Optional[str] = None,
+        html_message: Optional[str] = None,
+    ) -> Optional[str]:
+        raw = create_email(
+            message_from=message_from,
+            message_to=message_to,
+            message_cc=message_cc,
+            subject=subject,
+            message_headers=message_headers,
+            attachments=attachments,
+            plain_message=plain_message,
+            html_message=html_message,
+        )
+        encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+        body: dict = {"raw": encoded}
+        sent = (
+            self.service.users()
+            .messages()
+            .send(userId="me", body=body)
+            .execute()
+        )
+        return sent.get("id")
+
+    @lru_cache(maxsize=10)
+    def _find_label_id_for_label(self, label_name: str) -> str:
+        results = self.service.users().labels().list(userId="me").execute()
+        for label in results.get("labels", []):
+            if label_name == label["id"] or label_name == label["name"]:
+                return label["id"]
+        return ""

--- a/mailsuite/mailbox/graph.py
+++ b/mailsuite/mailbox/graph.py
@@ -1,0 +1,474 @@
+"""Microsoft Graph mailbox backend"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from enum import Enum
+from functools import lru_cache
+from pathlib import Path
+from time import sleep
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+from mailsuite.mailbox.base import MailboxConnection
+
+try:
+    from azure.identity import (
+        AuthenticationRecord,
+        CertificateCredential,
+        ClientSecretCredential,
+        DeviceCodeCredential,
+        TokenCachePersistenceOptions,
+        UsernamePasswordCredential,
+    )
+    from msgraph.graph_service_client import GraphServiceClient
+    from msgraph.generated.models.body_type import BodyType
+    from msgraph.generated.models.email_address import EmailAddress
+    from msgraph.generated.models.file_attachment import FileAttachment
+    from msgraph.generated.models.item_body import ItemBody
+    from msgraph.generated.models.mail_folder import MailFolder
+    from msgraph.generated.models.message import Message
+    from msgraph.generated.models.recipient import Recipient
+    from msgraph.generated.users.item.mail_folders.item.child_folders.child_folders_request_builder import (  # noqa: E501
+        ChildFoldersRequestBuilder,
+    )
+    from msgraph.generated.users.item.mail_folders.mail_folders_request_builder import (
+        MailFoldersRequestBuilder,
+    )
+    from msgraph.generated.users.item.mail_folders.item.messages.messages_request_builder import (  # noqa: E501
+        MessagesRequestBuilder,
+    )
+    from msgraph.generated.users.item.messages.item.move.move_post_request_body import (
+        MovePostRequestBody,
+    )
+    from msgraph.generated.users.item.send_mail.send_mail_post_request_body import (
+        SendMailPostRequestBody,
+    )
+except ImportError as e:
+    raise ImportError(
+        "MSGraphConnection requires the 'msgraph' extra: "
+        "pip install mailsuite[msgraph]"
+    ) from e
+
+logger = logging.getLogger(__name__)
+
+
+class AuthMethod(Enum):
+    DeviceCode = 1
+    UsernamePassword = 2
+    ClientSecret = 3
+    Certificate = 4
+
+
+def _get_cache_args(token_path: Path, allow_unencrypted_storage: bool) -> dict:
+    cache_args: dict = {
+        "cache_persistence_options": TokenCachePersistenceOptions(
+            name="mailsuite", allow_unencrypted_storage=allow_unencrypted_storage
+        )
+    }
+    auth_record = _load_token(token_path)
+    if auth_record:
+        cache_args["authentication_record"] = AuthenticationRecord.deserialize(
+            auth_record
+        )
+    return cache_args
+
+
+def _load_token(token_path: Path) -> Optional[str]:
+    if not token_path.exists():
+        return None
+    with token_path.open() as token_file:
+        return token_file.read()
+
+
+def _cache_auth_record(record: AuthenticationRecord, token_path: Path) -> None:
+    token = record.serialize()
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    with token_path.open("w") as token_file:
+        token_file.write(token)
+
+
+def _generate_credential(auth_method: str, token_path: Path, **kwargs):
+    if auth_method == AuthMethod.DeviceCode.name:
+        return DeviceCodeCredential(
+            client_id=kwargs["client_id"],
+            disable_automatic_authentication=True,
+            tenant_id=kwargs["tenant_id"],
+            **_get_cache_args(
+                token_path,
+                allow_unencrypted_storage=kwargs["allow_unencrypted_storage"],
+            ),
+        )
+    if auth_method == AuthMethod.UsernamePassword.name:
+        return UsernamePasswordCredential(
+            client_id=kwargs["client_id"],
+            client_credential=kwargs["client_secret"],
+            disable_automatic_authentication=True,
+            username=kwargs["username"],
+            password=kwargs["password"],
+            **_get_cache_args(
+                token_path,
+                allow_unencrypted_storage=kwargs["allow_unencrypted_storage"],
+            ),
+        )
+    if auth_method == AuthMethod.ClientSecret.name:
+        return ClientSecretCredential(
+            client_id=kwargs["client_id"],
+            tenant_id=kwargs["tenant_id"],
+            client_secret=kwargs["client_secret"],
+        )
+    if auth_method == AuthMethod.Certificate.name:
+        cert_path = kwargs.get("certificate_path")
+        if not cert_path:
+            raise ValueError(
+                "certificate_path is required when auth_method is 'Certificate'"
+            )
+        return CertificateCredential(
+            client_id=kwargs["client_id"],
+            tenant_id=kwargs["tenant_id"],
+            certificate_path=cert_path,
+            password=kwargs.get("certificate_password"),
+        )
+    raise RuntimeError(f"Auth method {auth_method} not found")
+
+
+def _run(coro):
+    """Run a coroutine to completion. Refuses to nest in a running loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    raise RuntimeError(
+        "MSGraphConnection cannot be called from inside a running event loop. "
+        "Use msgraph.GraphServiceClient directly from async code."
+    )
+
+
+class MSGraphConnection(MailboxConnection):
+    """
+    A :class:`MailboxConnection` backed by Microsoft Graph
+
+    Supports DeviceCode, UsernamePassword, ClientSecret, and Certificate
+    auth via :mod:`azure.identity`. Send mail goes through
+    ``/users/{mailbox}/sendMail`` with a structured ``Message`` body
+    (Graph automatically saves a copy to Sent Items).
+
+    Requires the ``msgraph`` extra::
+
+        pip install mailsuite[msgraph]
+    """
+
+    _WELL_KNOWN_FOLDERS = {
+        "inbox": "inbox",
+        "archive": "archive",
+        "drafts": "drafts",
+        "sentitems": "sentitems",
+        "deleteditems": "deleteditems",
+        "junkemail": "junkemail",
+    }
+
+    def __init__(
+        self,
+        auth_method: str,
+        mailbox: str,
+        client_id: str,
+        client_secret: Optional[str],
+        username: Optional[str],
+        password: Optional[str],
+        tenant_id: str,
+        token_file: str,
+        allow_unencrypted_storage: bool,
+        certificate_path: Optional[str] = None,
+        certificate_password: Optional[Union[str, bytes]] = None,
+    ):
+        token_path = Path(token_file)
+        credential = _generate_credential(
+            auth_method,
+            client_id=client_id,
+            client_secret=client_secret,
+            certificate_path=certificate_path,
+            certificate_password=certificate_password,
+            username=username,
+            password=password,
+            tenant_id=tenant_id,
+            token_path=token_path,
+            allow_unencrypted_storage=allow_unencrypted_storage,
+        )
+
+        scopes: Optional[List[str]] = None
+        if not isinstance(credential, (ClientSecretCredential, CertificateCredential)):
+            scopes = ["Mail.ReadWrite"]
+            # Detect if mailbox is shared
+            if mailbox and username and username != mailbox:
+                scopes = ["Mail.ReadWrite.Shared"]
+            auth_record = credential.authenticate(scopes=scopes)
+            _cache_auth_record(auth_record, token_path)
+
+        self._client = GraphServiceClient(credentials=credential, scopes=scopes)
+        self.mailbox_name = mailbox
+
+    # — folder management —
+
+    def create_folder(self, folder_name: str) -> None:
+        path_parts = folder_name.split("/")
+        parent_folder_id: Optional[str] = None
+        if len(path_parts) > 1:
+            for folder in path_parts[:-1]:
+                parent_folder_id = self._find_folder_id_with_parent(
+                    folder, parent_folder_id
+                )
+            folder_name = path_parts[-1]
+
+        body = MailFolder(display_name=folder_name)
+        try:
+            if parent_folder_id is None:
+                _run(
+                    self._client.users.by_user_id(
+                        self.mailbox_name
+                    ).mail_folders.post(body)
+                )
+            else:
+                _run(
+                    self._client.users.by_user_id(self.mailbox_name)
+                    .mail_folders.by_mail_folder_id(parent_folder_id)
+                    .child_folders.post(body)
+                )
+            logger.debug("Created folder %s", folder_name)
+        except Exception as e:
+            # 409 / "already exists" is normal — surface other errors
+            if "already exists" in str(e).lower() or "ErrorFolderExists" in str(e):
+                logger.debug("Folder %s already exists, skipping", folder_name)
+                return
+            raise
+
+    # — message reading —
+
+    def fetch_messages(self, reports_folder: str, **kwargs: Any) -> List[str]:
+        folder_id = self._find_folder_id_from_folder_path(reports_folder)
+        since = kwargs.get("since") or None
+        batch_size = kwargs.get("batch_size") or 0
+        return _run(self._fetch_messages_async(folder_id, batch_size, since))
+
+    async def _fetch_messages_async(
+        self, folder_id: str, batch_size: int, since: Optional[str]
+    ) -> List[str]:
+        query = MessagesRequestBuilder.MessagesRequestBuilderGetQueryParameters(
+            select=["id"],
+            top=batch_size if batch_size > 0 else 100,
+        )
+        if since:
+            query.filter = f"receivedDateTime ge {since}"
+        config = (
+            MessagesRequestBuilder.MessagesRequestBuilderGetRequestConfiguration(
+                query_parameters=query
+            )
+        )
+        page = (
+            await self._client.users.by_user_id(self.mailbox_name)
+            .mail_folders.by_mail_folder_id(folder_id)
+            .messages.get(request_configuration=config)
+        )
+        ids: List[str] = []
+        while page is not None and page.value:
+            ids.extend(m.id for m in page.value if m.id)
+            next_link = page.odata_next_link
+            keep_going = since is not None or batch_size == 0 or len(ids) < batch_size
+            if not next_link or not keep_going:
+                break
+            page = (
+                await self._client.users.by_user_id(self.mailbox_name)
+                .mail_folders.by_mail_folder_id(folder_id)
+                .messages.with_url(next_link)
+                .get()
+            )
+        return ids
+
+    def fetch_message(self, message_id: Any, **kwargs: Any) -> str:
+        raw = _run(
+            self._client.users.by_user_id(self.mailbox_name)
+            .messages.by_message_id(str(message_id))
+            .content.get()
+        )
+        if kwargs.get("mark_read"):
+            self.mark_message_read(str(message_id))
+        if isinstance(raw, bytes):
+            return raw.decode("utf-8", errors="replace")
+        return raw or ""
+
+    def mark_message_read(self, message_id: str) -> None:
+        _run(
+            self._client.users.by_user_id(self.mailbox_name)
+            .messages.by_message_id(message_id)
+            .patch(Message(is_read=True))
+        )
+
+    def delete_message(self, message_id: Any) -> None:
+        _run(
+            self._client.users.by_user_id(self.mailbox_name)
+            .messages.by_message_id(str(message_id))
+            .delete()
+        )
+
+    def move_message(self, message_id: Any, folder_name: str) -> None:
+        folder_id = self._find_folder_id_from_folder_path(folder_name)
+        body = MovePostRequestBody(destination_id=folder_id)
+        _run(
+            self._client.users.by_user_id(self.mailbox_name)
+            .messages.by_message_id(str(message_id))
+            .move.post(body)
+        )
+
+    def keepalive(self) -> None:
+        # Graph uses bearer tokens; nothing to ping
+        return
+
+    def watch(
+        self,
+        check_callback: Callable[[MailboxConnection], None],
+        check_timeout: int,
+        config_reloading: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        """Poll the mailbox at ``check_timeout``-second intervals"""
+        while True:
+            if config_reloading and config_reloading():
+                return
+            sleep(check_timeout)
+            if config_reloading and config_reloading():
+                return
+            check_callback(self)
+
+    # — sending —
+
+    def send_message(
+        self,
+        message_from: str,
+        message_to: Optional[List[str]] = None,
+        message_cc: Optional[List[str]] = None,
+        message_bcc: Optional[List[str]] = None,
+        subject: Optional[str] = None,
+        message_headers: Optional[dict] = None,
+        attachments: Optional[List[Tuple[str, bytes]]] = None,
+        plain_message: Optional[str] = None,
+        html_message: Optional[str] = None,
+    ) -> Optional[str]:
+        # Graph derives ``From`` from the authenticated mailbox; ``message_from``
+        # and ``message_headers`` are accepted for API parity but not used by
+        # the structured /sendMail endpoint.
+        del message_from, message_headers
+
+        if html_message is not None:
+            body = ItemBody(content_type=BodyType.Html, content=html_message)
+        else:
+            body = ItemBody(content_type=BodyType.Text, content=plain_message or "")
+
+        def _to_recipients(addrs: Optional[List[str]]) -> Optional[List[Recipient]]:
+            if not addrs:
+                return None
+            return [
+                Recipient(email_address=EmailAddress(address=addr)) for addr in addrs
+            ]
+
+        graph_attachments: Optional[List[Any]] = None
+        if attachments:
+            graph_attachments = [
+                FileAttachment(
+                    odata_type="#microsoft.graph.fileAttachment",
+                    name=filename,
+                    content_bytes=payload,
+                )
+                for filename, payload in attachments
+            ]
+
+        message = Message(
+            subject=subject,
+            body=body,
+            to_recipients=_to_recipients(message_to),
+            cc_recipients=_to_recipients(message_cc),
+            bcc_recipients=_to_recipients(message_bcc),
+            attachments=graph_attachments,
+        )
+        request = SendMailPostRequestBody(message=message, save_to_sent_items=True)
+        _run(
+            self._client.users.by_user_id(self.mailbox_name).send_mail.post(request)
+        )
+        return None
+
+    # — folder ID resolution —
+
+    @lru_cache(maxsize=10)
+    def _find_folder_id_from_folder_path(self, folder_name: str) -> str:
+        path_parts = folder_name.split("/")
+        parent_folder_id: Optional[str] = None
+        if len(path_parts) > 1:
+            for folder in path_parts[:-1]:
+                parent_folder_id = self._find_folder_id_with_parent(
+                    folder, parent_folder_id
+                )
+            return self._find_folder_id_with_parent(path_parts[-1], parent_folder_id)
+        return self._find_folder_id_with_parent(folder_name, None)
+
+    def _get_well_known_folder_id(self, folder_name: str) -> Optional[str]:
+        folder_key = folder_name.lower().replace(" ", "").replace("-", "")
+        alias = self._WELL_KNOWN_FOLDERS.get(folder_key)
+        if alias is None:
+            return None
+        try:
+            folder = _run(
+                self._client.users.by_user_id(self.mailbox_name)
+                .mail_folders.by_mail_folder_id(alias)
+                .get()
+            )
+        except Exception:
+            return None
+        return folder.id if folder else None
+
+    def _find_folder_id_with_parent(
+        self, folder_name: str, parent_folder_id: Optional[str]
+    ) -> str:
+        try:
+            folders = self._list_folders_filtered(folder_name, parent_folder_id)
+        except Exception as e:
+            if parent_folder_id is None:
+                well_known = self._get_well_known_folder_id(folder_name)
+                if well_known:
+                    return well_known
+            raise RuntimeError(f"Failed to list folders: {e}") from e
+
+        for folder in folders:
+            if folder.display_name == folder_name and folder.id:
+                return folder.id
+
+        if parent_folder_id is None:
+            well_known = self._get_well_known_folder_id(folder_name)
+            if well_known:
+                return well_known
+        raise RuntimeError(f"folder {folder_name} not found")
+
+    def _list_folders_filtered(
+        self, folder_name: str, parent_folder_id: Optional[str]
+    ) -> List[MailFolder]:
+        if parent_folder_id is None:
+            query = MailFoldersRequestBuilder.MailFoldersRequestBuilderGetQueryParameters(
+                filter=f"displayName eq '{folder_name}'"
+            )
+            config = MailFoldersRequestBuilder.MailFoldersRequestBuilderGetRequestConfiguration(
+                query_parameters=query
+            )
+            page = _run(
+                self._client.users.by_user_id(
+                    self.mailbox_name
+                ).mail_folders.get(request_configuration=config)
+            )
+        else:
+            child_query = ChildFoldersRequestBuilder.ChildFoldersRequestBuilderGetQueryParameters(
+                filter=f"displayName eq '{folder_name}'"
+            )
+            child_config = ChildFoldersRequestBuilder.ChildFoldersRequestBuilderGetRequestConfiguration(
+                query_parameters=child_query
+            )
+            page = _run(
+                self._client.users.by_user_id(self.mailbox_name)
+                .mail_folders.by_mail_folder_id(parent_folder_id)
+                .child_folders.get(request_configuration=child_config)
+            )
+        return list(page.value or []) if page is not None else []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,20 @@ dynamic = [
     "version",
 ]
 
+[project.optional-dependencies]
+msgraph = [
+    "azure-identity>=1.15.0",
+    "msgraph-sdk>=1.0.0",
+]
+gmail = [
+    "google-api-python-client>=2.0.0",
+    "google-auth>=2.0.0",
+    "google-auth-oauthlib>=1.0.0",
+]
+all = [
+    "mailsuite[msgraph,gmail]",
+]
+
 [project.urls]
 Homepage = "https://github.com/seanthegeek/mailsuite/"
 Documentation = "https://seanthegeek.github.io/mailsuite/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,26 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["mailsuite"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-ra --strict-markers"
+filterwarnings = [
+    "ignore::DeprecationWarning:mailparser",
+    "ignore::DeprecationWarning:imapclient",
+    "ignore::DeprecationWarning:msgraph.*",
+    "ignore::RuntimeWarning",
+]
+
+[tool.coverage.run]
+source = ["mailsuite"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,11 @@ publicsuffix2>=2.20190812
 expiringdict==1.2.2
 dkimpy>=1.1.0
 cryptography>=41.0.0
+msgraph-sdk>=1.0.0
+azure-identity>=1.15.0
+google-api-python-client>=2.0.0
+google-auth>=2.0.0
+google-auth-oauthlib>=1.0.0
 nose
 pygments
 ruff

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+from mailsuite.dkim import generate_dkim_keypair
+
+
+@pytest.fixture(scope="session")
+def dkim_keypair() -> tuple[str, str]:
+    """A 2048-bit RSA DKIM keypair shared across tests for speed."""
+    return generate_dkim_keypair(key_size=2048)
+
+
+@pytest.fixture
+def sample_email_str() -> str:
+    """A minimal RFC 822 message used by signing/parsing tests."""
+    return (
+        "From: Sender <sender@example.com>\r\n"
+        "To: recipient@example.org\r\n"
+        "Subject: Hello\r\n"
+        "Date: Mon, 27 Apr 2026 12:00:00 +0000\r\n"
+        "Message-ID: <test@example.com>\r\n"
+        "MIME-Version: 1.0\r\n"
+        "Content-Type: text/plain\r\n"
+        "\r\n"
+        "Hello world\r\n"
+    )

--- a/tests/test_dkim.py
+++ b/tests/test_dkim.py
@@ -1,0 +1,298 @@
+"""Tests for mailsuite.dkim."""
+
+from __future__ import annotations
+
+import dkim as _dkim
+import pytest
+
+from mailsuite.dkim import (
+    DEFAULT_SIGNED_HEADERS,
+    DKIMError,
+    generate_dkim_keypair,
+    generate_dkim_private_key,
+    generate_dkim_txt_record,
+    get_dkim_public_key,
+    sign_email,
+    verify_email,
+)
+
+
+class TestKeyGeneration:
+    def test_generate_private_key_default(self):
+        pem = generate_dkim_private_key()
+        assert pem.startswith("-----BEGIN PRIVATE KEY-----")
+        assert "END PRIVATE KEY" in pem
+
+    def test_generate_private_key_custom_size(self):
+        pem = generate_dkim_private_key(key_size=1024)
+        assert pem.startswith("-----BEGIN PRIVATE KEY-----")
+
+    def test_reject_undersize_key(self):
+        with pytest.raises(ValueError, match="at least 1024"):
+            generate_dkim_private_key(key_size=512)
+
+    def test_keypair_pair(self, dkim_keypair):
+        priv, pub = dkim_keypair
+        assert priv.startswith("-----BEGIN PRIVATE KEY-----")
+        # public key is base64 SubjectPublicKeyInfo (no PEM markers)
+        assert "BEGIN" not in pub
+        assert len(pub) > 100
+
+    def test_get_public_key_str_input(self, dkim_keypair):
+        priv, pub = dkim_keypair
+        assert get_dkim_public_key(priv) == pub
+
+    def test_get_public_key_bytes_input(self, dkim_keypair):
+        priv, pub = dkim_keypair
+        assert get_dkim_public_key(priv.encode()) == pub
+
+    def test_get_public_key_bytearray_input(self, dkim_keypair):
+        priv, pub = dkim_keypair
+        assert get_dkim_public_key(bytearray(priv.encode())) == pub
+
+    def test_get_public_key_invalid_pem(self):
+        with pytest.raises(DKIMError, match="Failed to load private key"):
+            get_dkim_public_key("not a key")
+
+
+class TestTxtRecord:
+    def test_record_value_only(self, dkim_keypair):
+        _, pub = dkim_keypair
+        record = generate_dkim_txt_record(pub)
+        assert record.startswith("v=DKIM1")
+        assert "k=rsa" in record
+        assert f"p={pub}" in record
+
+    def test_record_with_domain(self, dkim_keypair):
+        _, pub = dkim_keypair
+        record = generate_dkim_txt_record(pub, selector="ms1", domain="example.com")
+        assert record.startswith("ms1._domainkey.example.com.")
+        assert "IN" in record
+        assert "TXT" in record
+        assert "v=DKIM1" in record
+
+    def test_record_strips_trailing_dot_in_domain(self, dkim_keypair):
+        _, pub = dkim_keypair
+        record = generate_dkim_txt_record(pub, selector="ms1", domain="example.com.")
+        assert "example.com." in record
+        assert "example.com.." not in record
+
+    def test_record_from_pem_private_key(self, dkim_keypair):
+        priv, pub = dkim_keypair
+        record = generate_dkim_txt_record(priv)
+        assert f"p={pub}" in record
+
+    def test_record_from_pem_public_key(self, dkim_keypair):
+        from cryptography.hazmat.primitives import serialization
+
+        priv, pub = dkim_keypair
+        key = serialization.load_pem_private_key(priv.encode(), password=None)
+        pub_pem = key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        record = generate_dkim_txt_record(pub_pem)
+        assert f"p={pub}" in record
+
+    def test_record_with_flags_and_note(self, dkim_keypair):
+        _, pub = dkim_keypair
+        record = generate_dkim_txt_record(pub, flags="y", note="test mode")
+        assert "t=y" in record
+        assert "n=test mode" in record
+
+    def test_record_strips_whitespace_from_b64(self, dkim_keypair):
+        _, pub = dkim_keypair
+        record = generate_dkim_txt_record(f"  {pub[:40]}\n{pub[40:]}  ")
+        assert " " not in record.split("p=", 1)[1]
+
+    def test_record_bytes_input(self, dkim_keypair):
+        _, pub = dkim_keypair
+        record = generate_dkim_txt_record(pub.encode())
+        assert "v=DKIM1" in record
+
+    def test_record_invalid_pem_public_key(self):
+        with pytest.raises(DKIMError, match="Failed to load public key"):
+            generate_dkim_txt_record(
+                "-----BEGIN PUBLIC KEY-----\nnotreal\n-----END PUBLIC KEY-----"
+            )
+
+
+class TestSignEmail:
+    def _dns_func_for(self, pub: str):
+        record = generate_dkim_txt_record(pub).encode()
+
+        def fake(name, timeout=5):
+            return record
+
+        return fake
+
+    def test_sign_str_input(self, dkim_keypair, sample_email_str):
+        priv, _ = dkim_keypair
+        signed = sign_email(sample_email_str, "ms1", "example.com", priv)
+        assert isinstance(signed, str)
+        assert signed.startswith("DKIM-Signature: ")
+
+    def test_sign_bytes_input(self, dkim_keypair, sample_email_str):
+        priv, _ = dkim_keypair
+        signed = sign_email(sample_email_str.encode(), "ms1", "example.com", priv)
+        assert isinstance(signed, bytes)
+        assert signed.startswith(b"DKIM-Signature: ")
+
+    def test_sign_bytes_private_key(self, dkim_keypair, sample_email_str):
+        priv, _ = dkim_keypair
+        signed = sign_email(sample_email_str, "ms1", "example.com", priv.encode())
+        assert signed.startswith("DKIM-Signature: ")
+
+    def test_signed_message_verifies(self, dkim_keypair, sample_email_str):
+        priv, pub = dkim_keypair
+        signed = sign_email(sample_email_str, "ms1", "example.com", priv)
+        assert _dkim.verify(signed.encode(), dnsfunc=self._dns_func_for(pub)) is True
+
+    def test_additional_headers(self, dkim_keypair):
+        priv, pub = dkim_keypair
+        msg = (
+            "From: a@example.com\r\n"
+            "To: b@example.org\r\n"
+            "Subject: x\r\n"
+            "X-Custom: yes\r\n"
+            "\r\n"
+            "body\r\n"
+        )
+        signed = sign_email(
+            msg, "ms1", "example.com", priv, additional_headers=["X-Custom", "X-Missing"]
+        )
+        # verify still passes
+        assert _dkim.verify(signed.encode(), dnsfunc=self._dns_func_for(pub)) is True
+        # x-custom appears in the h= tag of the signature
+        sig_line = signed.split("\r\n\r\n", 1)[0].split("DKIM-Signature: ", 1)[1]
+        assert "x-custom" in sig_line.lower()
+
+    def test_no_from_header_raises(self, dkim_keypair):
+        priv, _ = dkim_keypair
+        with pytest.raises(DKIMError, match="From header"):
+            sign_email("Subject: x\r\n\r\nbody\r\n", "ms1", "example.com", priv)
+
+    def test_explicit_identity(self, dkim_keypair, sample_email_str):
+        priv, pub = dkim_keypair
+        signed = sign_email(
+            sample_email_str, "ms1", "example.com", priv, identity="@example.com"
+        )
+        assert _dkim.verify(signed.encode(), dnsfunc=self._dns_func_for(pub)) is True
+
+    def test_dkim_exception_wrapped(self, dkim_keypair, sample_email_str):
+        # Identity that doesn't end with the domain → ParameterError → DKIMError
+        priv, _ = dkim_keypair
+        with pytest.raises(DKIMError):
+            sign_email(
+                sample_email_str,
+                "ms1",
+                "example.com",
+                priv,
+                identity="@other.example",
+            )
+
+    def test_default_signed_headers_are_oversigned(self):
+        # From/To/Cc/Subject appear twice for oversigning
+        for name in ("From", "To", "Cc", "Subject"):
+            assert DEFAULT_SIGNED_HEADERS.count(name) == 2
+
+
+class TestVerifyEmail:
+    def _signed_with(self, priv: str, msg: str, **kwargs) -> str:
+        return sign_email(msg, "ms1", "example.com", priv, **kwargs)
+
+    def _dns_func_for(self, pub: str):
+        record = generate_dkim_txt_record(pub).encode()
+
+        def fake(name, timeout=5):
+            return record
+
+        return fake
+
+    def test_valid_signature(self, dkim_keypair, sample_email_str):
+        priv, pub = dkim_keypair
+        signed = self._signed_with(priv, sample_email_str)
+        result = verify_email(signed, dns_func=self._dns_func_for(pub))
+        assert result["valid"] is True
+        assert len(result["signatures"]) == 1
+        sig = result["signatures"][0]
+        assert sig["domain"] == "example.com"
+        assert sig["selector"] == "ms1"
+        assert sig["valid"] is True
+        assert sig["error"] is None
+
+    def test_bytes_input(self, dkim_keypair, sample_email_str):
+        priv, pub = dkim_keypair
+        signed = self._signed_with(priv, sample_email_str)
+        result = verify_email(signed.encode(), dns_func=self._dns_func_for(pub))
+        assert result["valid"] is True
+
+    def test_wrong_dns_key(self, dkim_keypair, sample_email_str):
+        priv, _ = self._noop_keys(dkim_keypair)
+        _, wrong_pub = generate_dkim_keypair(2048)
+        signed = self._signed_with(priv, sample_email_str)
+        result = verify_email(signed, dns_func=self._dns_func_for(wrong_pub))
+        assert result["valid"] is False
+        assert result["signatures"][0]["error"] is not None
+
+    def test_tampered_body(self, dkim_keypair, sample_email_str):
+        priv, pub = dkim_keypair
+        signed = self._signed_with(priv, sample_email_str)
+        tampered = signed.replace("Hello world", "Goodbye world")
+        result = verify_email(tampered, dns_func=self._dns_func_for(pub))
+        assert result["valid"] is False
+        assert "body hash mismatch" in result["signatures"][0]["error"]
+
+    def test_no_signatures(self, dkim_keypair, sample_email_str):
+        _, pub = dkim_keypair
+        result = verify_email(sample_email_str, dns_func=self._dns_func_for(pub))
+        assert result["valid"] is False
+        assert result["signatures"] == []
+
+    def test_multiple_signatures_all_valid(self, dkim_keypair, sample_email_str):
+        priv, pub = dkim_keypair
+        signed_once = self._signed_with(priv, sample_email_str)
+        signed_twice = sign_email(signed_once, "ms2", "example.com", priv)
+        result = verify_email(signed_twice, dns_func=self._dns_func_for(pub))
+        assert result["valid"] is True
+        assert len(result["signatures"]) == 2
+
+    def test_multiple_signatures_mixed(self, dkim_keypair, sample_email_str):
+        priv, pub = dkim_keypair
+        priv2, pub2 = generate_dkim_keypair(2048)
+        signed_once = self._signed_with(priv, sample_email_str)
+        signed_twice = sign_email(signed_once, "ms2", "example.com", priv)
+
+        record_pub = generate_dkim_txt_record(pub).encode()
+        record_pub2 = generate_dkim_txt_record(pub2).encode()
+
+        def selective_dns(name, timeout=5):
+            if name.startswith(b"ms2."):
+                return record_pub2
+            return record_pub
+
+        result = verify_email(signed_twice, dns_func=selective_dns)
+        # ms1 valid, ms2 invalid → at least one valid → overall True
+        assert result["valid"] is True
+        valid = [s for s in result["signatures"] if s["valid"]]
+        invalid = [s for s in result["signatures"] if not s["valid"]]
+        assert len(valid) == 1 and len(invalid) == 1
+
+    def test_malformed_signature_header(self, dkim_keypair):
+        # A DKIM-Signature header that fails parse_tag_value gets caught and
+        # reported as an error rather than raising.
+        msg = (
+            "From: a@example.com\r\n"
+            "To: b@example.org\r\n"
+            "DKIM-Signature: this is not a real DKIM-Signature value\r\n"
+            "Subject: x\r\n"
+            "\r\n"
+            "body\r\n"
+        )
+        result = verify_email(msg, dns_func=lambda *a, **k: b"")
+        assert result["valid"] is False
+        assert len(result["signatures"]) == 1
+
+    @staticmethod
+    def _noop_keys(keypair):
+        return keypair

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -1,0 +1,313 @@
+"""Tests for mailsuite.imap.
+
+Network I/O is bypassed: we construct IMAPClient instances via __new__
+and stub the methods inherited from imapclient.IMAPClient that ours
+delegate to. This focuses tests on the local logic — fetch retry
+handling, delete/move chunking, folder normalization — rather than
+re-testing imapclient itself.
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock
+
+import imapclient
+import imapclient.exceptions
+import pytest
+
+from mailsuite.imap import IMAPClient, MaxRetriesExceeded, _chunks
+
+
+def _bare_client(
+    *,
+    hierarchy_separator: str = "/",
+    path_prefix: str = "",
+    move_supported: bool = True,
+    max_retries: int = 4,
+) -> IMAPClient:
+    """Build an IMAPClient without doing any network setup."""
+    inst = IMAPClient.__new__(IMAPClient)
+    inst._hierarchy_separator = hierarchy_separator
+    inst._path_prefix = path_prefix
+    inst._move_supported = move_supported
+    inst.max_retries = max_retries
+    inst._init_args = {
+        "host": "h",
+        "username": "u",
+        "password": "p",
+        "port": 993,
+        "ssl": True,
+        "ssl_context": None,
+        "verify": True,
+        "timeout": 30,
+        "max_retries": max_retries,
+        "initial_folder": "INBOX",
+        "idle_callback": None,
+        "idle_timeout": 30,
+    }
+    return inst
+
+
+class TestChunks:
+    def test_basic(self):
+        assert list(_chunks([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+
+    def test_empty(self):
+        assert list(_chunks([], 5)) == []
+
+
+class TestNormaliseFolder:
+    def test_inbox_passthrough(self, monkeypatch):
+        client = _bare_client(hierarchy_separator="/")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: f"NORMALISED:{name}",
+        )
+        # Special folders are returned by base impl directly
+        assert "INBOX" in client._normalise_folder("INBOX")
+
+    def test_bytes_input_decoded(self, monkeypatch):
+        client = _bare_client(hierarchy_separator="/")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        assert client._normalise_folder(b"INBOX") == "INBOX"
+
+    def test_bytearray_input_decoded(self, monkeypatch):
+        client = _bare_client(hierarchy_separator="/")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        assert client._normalise_folder(bytearray(b"INBOX")) == "INBOX"
+
+    def test_memoryview_input_decoded(self, monkeypatch):
+        client = _bare_client(hierarchy_separator="/")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        assert client._normalise_folder(memoryview(b"INBOX")) == "INBOX"
+
+    def test_translates_separators(self, monkeypatch):
+        client = _bare_client(hierarchy_separator=".")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        # path with "/" should be converted to "."
+        assert client._normalise_folder("Reports/2026") == "Reports.2026"
+
+    def test_path_prefix_added(self, monkeypatch):
+        client = _bare_client(hierarchy_separator="/", path_prefix="INBOX/")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        assert client._normalise_folder("Reports") == "INBOX/Reports"
+
+
+class TestFetchMessage:
+    def _client(self):
+        client = _bare_client()
+        client.fetch = MagicMock()
+        client.reset_connection = MagicMock()
+        return client
+
+    def test_first_fetch_succeeds(self):
+        client = self._client()
+        client.fetch.return_value = {42: {b"RFC822": b"raw msg"}}
+        assert client.fetch_message(42) == "raw msg"
+
+    def test_falls_back_to_body(self):
+        client = self._client()
+        # First two attempts return responses without RFC822 / BODY[] keys
+        client.fetch.side_effect = [
+            {42: {b"FLAGS": ()}},
+            {42: {b"BODY[]": b"the body"}},
+        ]
+        assert client.fetch_message(42) == "the body"
+        assert client.fetch.call_count == 2
+
+    def test_falls_back_to_body_null(self):
+        client = self._client()
+        client.fetch.side_effect = [
+            {42: {b"FLAGS": ()}},
+            {42: {b"FLAGS": ()}},
+            {42: {b"BODY[NULL]": b"null body"}},
+        ]
+        assert client.fetch_message(42) == "null body"
+        assert client.fetch.call_count == 3
+
+    def test_no_recognised_keys_raises(self):
+        client = self._client()
+        client.fetch.return_value = {42: {b"FLAGS": ()}}
+        with pytest.raises(KeyError):
+            client.fetch_message(42)
+
+    def test_imapclient_error_skips_to_next_attempt(self):
+        client = self._client()
+        client.fetch.side_effect = [
+            imapclient.exceptions.IMAPClientError("boom"),
+            {42: {b"BODY[]": b"recovered"}},
+        ]
+        assert client.fetch_message(42) == "recovered"
+
+    def test_socket_timeout_triggers_retry(self):
+        client = self._client()
+        client.max_retries = 2
+        # first call raises socket.timeout, retry succeeds
+        client.fetch.side_effect = [
+            socket.timeout(),
+            {42: {b"RFC822": b"after retry"}},
+        ]
+        assert client.fetch_message(42) == "after retry"
+        client.reset_connection.assert_called_once()
+
+    def test_max_retries_exceeded(self):
+        client = self._client()
+        client.max_retries = 2
+        client.fetch.side_effect = socket.timeout()
+        with pytest.raises(MaxRetriesExceeded):
+            client.fetch_message(42)
+
+
+class TestDeleteMessages:
+    def _client(self):
+        client = _bare_client()
+        client.reset_connection = MagicMock()
+        return client
+
+    def test_int_coerced_to_list(self, monkeypatch):
+        called = {}
+
+        def fake_delete(self, messages, silent=True):
+            called["messages"] = messages
+
+        def fake_expunge(self, messages):
+            called["expunged"] = messages
+
+        monkeypatch.setattr(imapclient.IMAPClient, "delete_messages", fake_delete)
+        monkeypatch.setattr(imapclient.IMAPClient, "expunge", fake_expunge)
+        client = self._client()
+        client.delete_messages(42)
+        assert called["messages"] == [42]
+
+    def test_retry_on_timeout(self, monkeypatch):
+        attempts = {"n": 0}
+
+        def fake_delete(self, messages, silent=True):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise socket.timeout()
+
+        monkeypatch.setattr(imapclient.IMAPClient, "delete_messages", fake_delete)
+        monkeypatch.setattr(
+            imapclient.IMAPClient, "expunge", lambda self, m: None
+        )
+        client = self._client()
+        client.max_retries = 3
+        client.delete_messages([1, 2])
+        assert attempts["n"] == 2
+
+    def test_max_retries_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "delete_messages",
+            lambda self, m, silent=True: (_ for _ in ()).throw(socket.timeout()),
+        )
+        client = self._client()
+        client.max_retries = 2
+        with pytest.raises(MaxRetriesExceeded):
+            client.delete_messages([1])
+
+
+class TestCreateFolder:
+    def test_skips_when_exists(self, monkeypatch):
+        client = _bare_client()
+        client.folder_exists = MagicMock(return_value=True)
+        called = {"created": False}
+
+        def fake_create(self, folder):
+            called["created"] = True
+
+        monkeypatch.setattr(imapclient.IMAPClient, "create_folder", fake_create)
+        client.create_folder("Reports")
+        assert called["created"] is False
+
+    def test_creates_when_missing(self, monkeypatch):
+        client = _bare_client()
+        client.folder_exists = MagicMock(return_value=False)
+        called = {"name": None}
+
+        def fake_create(self, folder):
+            called["name"] = folder
+
+        monkeypatch.setattr(imapclient.IMAPClient, "create_folder", fake_create)
+        client.create_folder("Reports")
+        assert called["name"] == "Reports"
+
+    def test_max_retries_on_timeout(self, monkeypatch):
+        client = _bare_client()
+        client.folder_exists = MagicMock(return_value=False)
+        client.reset_connection = MagicMock()
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "create_folder",
+            lambda self, folder: (_ for _ in ()).throw(socket.timeout()),
+        )
+        client.max_retries = 2
+        with pytest.raises(MaxRetriesExceeded):
+            client.create_folder("Reports")
+
+
+class TestMoveMessages:
+    def _client(self, move_supported=True):
+        client = _bare_client(move_supported=move_supported)
+        client.reset_connection = MagicMock()
+        client.move = MagicMock()
+        client.copy = MagicMock()
+        return client
+
+    def test_move_when_supported(self, monkeypatch):
+        monkeypatch.setattr(
+            imapclient.IMAPClient, "delete_messages", lambda *a, **k: None
+        )
+        monkeypatch.setattr(imapclient.IMAPClient, "expunge", lambda *a, **k: None)
+        client = self._client(move_supported=True)
+        client.move_messages([1, 2, 3], "Archive")
+        client.move.assert_called_once()
+
+    def test_copy_fallback_when_move_unsupported(self, monkeypatch):
+        monkeypatch.setattr(
+            imapclient.IMAPClient, "delete_messages", lambda *a, **k: None
+        )
+        monkeypatch.setattr(imapclient.IMAPClient, "expunge", lambda *a, **k: None)
+        client = self._client(move_supported=False)
+        client.move_messages([1], "Archive")
+        client.copy.assert_called_once()
+        client.move.assert_not_called()
+
+    def test_copy_fallback_when_move_errors(self, monkeypatch):
+        monkeypatch.setattr(
+            imapclient.IMAPClient, "delete_messages", lambda *a, **k: None
+        )
+        monkeypatch.setattr(imapclient.IMAPClient, "expunge", lambda *a, **k: None)
+        client = self._client(move_supported=True)
+        client.move.side_effect = imapclient.exceptions.IMAPClientError("nope")
+        client.move_messages([1], "Archive")
+        # falls back to copy + delete
+        client.copy.assert_called_once()
+
+
+class TestExceptions:
+    def test_max_retries_is_runtime_error(self):
+        assert issubclass(MaxRetriesExceeded, RuntimeError)

--- a/tests/test_mailbox_base.py
+++ b/tests/test_mailbox_base.py
@@ -1,0 +1,50 @@
+"""Tests for mailsuite.mailbox.base.MailboxConnection ABC."""
+
+from __future__ import annotations
+
+import pytest
+
+from mailsuite.mailbox import MailboxConnection
+
+
+class TestABCDefaultMethods:
+    """Each method on the bare ABC should raise NotImplementedError."""
+
+    @pytest.fixture
+    def conn(self) -> MailboxConnection:
+        # MailboxConnection is an ABC, but it has no abstractmethod decorators
+        # — calling instantiates fine (a deliberate parsedmarc choice). Each
+        # method just raises NotImplementedError.
+        return MailboxConnection.__new__(MailboxConnection)
+
+    def test_create_folder(self, conn):
+        with pytest.raises(NotImplementedError):
+            conn.create_folder("Reports")
+
+    def test_fetch_messages(self, conn):
+        with pytest.raises(NotImplementedError):
+            conn.fetch_messages("INBOX")
+
+    def test_fetch_message(self, conn):
+        with pytest.raises(NotImplementedError):
+            conn.fetch_message("id")
+
+    def test_delete_message(self, conn):
+        with pytest.raises(NotImplementedError):
+            conn.delete_message("id")
+
+    def test_move_message(self, conn):
+        with pytest.raises(NotImplementedError):
+            conn.move_message("id", "Archive")
+
+    def test_keepalive(self, conn):
+        with pytest.raises(NotImplementedError):
+            conn.keepalive()
+
+    def test_watch(self, conn):
+        with pytest.raises(NotImplementedError):
+            conn.watch(lambda c: None, 30)
+
+    def test_send_message(self, conn):
+        with pytest.raises(NotImplementedError):
+            conn.send_message("a@example.com")

--- a/tests/test_mailbox_gmail.py
+++ b/tests/test_mailbox_gmail.py
@@ -1,0 +1,297 @@
+"""Tests for mailsuite.mailbox.gmail.GmailConnection.
+
+The Gmail SDK is fully mocked. We construct connections via __new__
+and inject a fake service builder so we don't need real OAuth or
+network I/O.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+
+# Skip everything if the optional [gmail] extra isn't installed.
+pytest.importorskip("googleapiclient")
+pytest.importorskip("google.oauth2.credentials")
+
+from googleapiclient.errors import HttpError  # noqa: E402
+
+from mailsuite.mailbox import MailboxConnection  # noqa: E402
+from mailsuite.mailbox.gmail import GmailConnection, _get_creds  # noqa: E402
+
+
+class FakeGmailService:
+    """A chainable MagicMock that records the last operation result."""
+
+    def __init__(self):
+        self.users_obj = MagicMock()
+        self.labels_obj = MagicMock()
+        self.messages_obj = MagicMock()
+        self.users_obj.return_value.labels.return_value = self.labels_obj
+        self.users_obj.return_value.messages.return_value = self.messages_obj
+
+    def users(self):
+        return self.users_obj()
+
+
+def _bare_connection(label_id: str = "L1") -> GmailConnection:
+    """Build a GmailConnection bypassing OAuth + service.build()."""
+    inst = GmailConnection.__new__(GmailConnection)
+    inst.service = FakeGmailService()
+    inst.include_spam_trash = False
+    inst.reports_label_id = label_id
+    inst.paginate_messages = True
+    return inst
+
+
+class TestSubclass:
+    def test_is_mailbox_connection(self):
+        assert issubclass(GmailConnection, MailboxConnection)
+
+
+class TestGetCreds:
+    def test_unsupported_auth_mode(self, tmp_path):
+        with pytest.raises(ValueError, match="Unsupported"):
+            _get_creds(
+                str(tmp_path / "tok.json"),
+                str(tmp_path / "creds.json"),
+                ["scope"],
+                0,
+                auth_mode="bogus",
+            )
+
+    def test_service_account(self, tmp_path, monkeypatch):
+        called = {}
+
+        class FakeSACredentials:
+            @classmethod
+            def from_service_account_file(cls, file, scopes=None):
+                called["file"] = file
+                called["scopes"] = scopes
+                inst = cls()
+                inst._with_subject = None
+                return inst
+
+            def with_subject(self, user):
+                self._with_subject = user
+                return self
+
+        # Patch the service_account module's Credentials class
+        from mailsuite.mailbox import gmail as gmail_mod
+
+        monkeypatch.setattr(
+            gmail_mod.service_account, "Credentials", FakeSACredentials
+        )
+        creds = _get_creds(
+            "ignored",
+            str(tmp_path / "creds.json"),
+            ["scope1"],
+            0,
+            auth_mode="service_account",
+            service_account_user="user@example.com",
+        )
+        assert called["scopes"] == ["scope1"]
+        assert creds._with_subject == "user@example.com"
+
+
+class TestCreateFolder:
+    def test_archive_skipped(self):
+        conn = _bare_connection()
+        conn.create_folder("Archive")
+        # No call to labels().create
+        conn.service.labels_obj.create.assert_not_called()
+
+    def test_creates_label(self):
+        conn = _bare_connection()
+        conn.service.labels_obj.create.return_value.execute.return_value = {}
+        conn.create_folder("Reports")
+        conn.service.labels_obj.create.assert_called_once()
+
+    def test_existing_label_409_swallowed(self):
+        conn = _bare_connection()
+        err = HttpError(
+            resp=MagicMock(status=409, reason="Conflict"),
+            content=b'{"error": "exists"}',
+        )
+        conn.service.labels_obj.create.return_value.execute.side_effect = err
+        # Should not raise
+        conn.create_folder("Reports")
+
+    def test_other_http_error_propagates(self):
+        conn = _bare_connection()
+        err = HttpError(
+            resp=MagicMock(status=500, reason="Server Error"),
+            content=b'{"error": "boom"}',
+        )
+        conn.service.labels_obj.create.return_value.execute.side_effect = err
+        with pytest.raises(HttpError):
+            conn.create_folder("Reports")
+
+
+class TestFetchMessages:
+    def test_single_page(self):
+        conn = _bare_connection()
+        conn._find_label_id_for_label = MagicMock(return_value="L42")
+        conn.service.messages_obj.list.return_value.execute.return_value = {
+            "messages": [{"id": "m1"}, {"id": "m2"}],
+        }
+        ids = conn.fetch_messages("Reports")
+        assert ids == ["m1", "m2"]
+
+    def test_paginates(self):
+        conn = _bare_connection()
+        conn._find_label_id_for_label = MagicMock(return_value="L42")
+        # Two pages: first has nextPageToken, second doesn't
+        conn.service.messages_obj.list.return_value.execute.side_effect = [
+            {"messages": [{"id": "m1"}], "nextPageToken": "tok"},
+            {"messages": [{"id": "m2"}]},
+        ]
+        ids = conn.fetch_messages("Reports")
+        assert ids == ["m1", "m2"]
+
+    def test_pagination_disabled(self):
+        conn = _bare_connection()
+        conn.paginate_messages = False
+        conn._find_label_id_for_label = MagicMock(return_value="L42")
+        conn.service.messages_obj.list.return_value.execute.side_effect = [
+            {"messages": [{"id": "m1"}], "nextPageToken": "tok"},
+        ]
+        ids = conn.fetch_messages("Reports")
+        assert ids == ["m1"]
+
+    def test_with_since_filter(self):
+        conn = _bare_connection()
+        conn._find_label_id_for_label = MagicMock(return_value="L42")
+        conn.service.messages_obj.list.return_value.execute.return_value = {
+            "messages": [{"id": "m1"}],
+        }
+        conn.fetch_messages("Reports", since="2026/04/01")
+        # The list call was made with q="after:..."
+        kwargs = conn.service.messages_obj.list.call_args.kwargs
+        assert kwargs["q"] == "after:2026/04/01"
+
+
+class TestFetchMessage:
+    def test_decodes_raw(self):
+        conn = _bare_connection()
+        body = "From: a\r\nSubject: test\r\n\r\nbody\r\n"
+        encoded = base64.urlsafe_b64encode(body.encode()).decode()
+        conn.service.messages_obj.get.return_value.execute.return_value = {
+            "raw": encoded
+        }
+        result = conn.fetch_message("m1")
+        assert "Subject: test" in result
+
+
+class TestDeleteMessage:
+    def test_calls_delete(self):
+        conn = _bare_connection()
+        conn.delete_message("m1")
+        conn.service.messages_obj.delete.assert_called_once_with(userId="me", id="m1")
+
+
+class TestMoveMessage:
+    def test_modifies_labels(self):
+        conn = _bare_connection(label_id="REPORTS")
+        conn._find_label_id_for_label = MagicMock(return_value="ARCHIVE")
+        conn.move_message("m1", "Archive")
+        kwargs = conn.service.messages_obj.modify.call_args.kwargs
+        assert kwargs["id"] == "m1"
+        assert kwargs["body"] == {
+            "addLabelIds": ["ARCHIVE"],
+            "removeLabelIds": ["REPORTS"],
+        }
+
+
+class TestSendMessage:
+    def test_sends_encoded_message(self, dkim_keypair):
+        conn = _bare_connection()
+        conn.service.messages_obj.send.return_value.execute.return_value = {
+            "id": "sent-123"
+        }
+        result = conn.send_message(
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            subject="hi",
+            plain_message="hello",
+        )
+        assert result == "sent-123"
+        body = conn.service.messages_obj.send.call_args.kwargs["body"]
+        assert "raw" in body
+        # Decode the raw and check the message looks right
+        raw = base64.urlsafe_b64decode(body["raw"]).decode()
+        assert "Subject: hi" in raw
+        assert "hello" in raw
+
+    def test_send_with_attachments(self):
+        conn = _bare_connection()
+        conn.service.messages_obj.send.return_value.execute.return_value = {"id": "s2"}
+        conn.send_message(
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            attachments=[("file.txt", b"data")],
+        )
+        body = conn.service.messages_obj.send.call_args.kwargs["body"]
+        raw = base64.urlsafe_b64decode(body["raw"]).decode()
+        assert "file.txt" in raw
+
+
+class TestKeepalive:
+    def test_no_op(self):
+        conn = _bare_connection()
+        conn.keepalive()
+
+
+class TestLabelLookup:
+    def test_finds_by_name(self):
+        conn = _bare_connection()
+        conn.service.labels_obj.list.return_value.execute.return_value = {
+            "labels": [
+                {"id": "L1", "name": "INBOX"},
+                {"id": "L42", "name": "Reports"},
+            ]
+        }
+        # bypass the lru_cache on the bound method by using the function directly
+        conn._find_label_id_for_label.cache_clear()
+        assert conn._find_label_id_for_label("Reports") == "L42"
+
+    def test_finds_by_id(self):
+        conn = _bare_connection()
+        conn.service.labels_obj.list.return_value.execute.return_value = {
+            "labels": [{"id": "L42", "name": "Reports"}]
+        }
+        conn._find_label_id_for_label.cache_clear()
+        assert conn._find_label_id_for_label("L42") == "L42"
+
+    def test_missing_returns_empty(self):
+        conn = _bare_connection()
+        conn.service.labels_obj.list.return_value.execute.return_value = {"labels": []}
+        conn._find_label_id_for_label.cache_clear()
+        assert conn._find_label_id_for_label("Nope") == ""
+
+
+class TestWatch:
+    def test_exits_on_config_reload(self):
+        conn = _bare_connection()
+        calls = {"n": 0}
+        conn.watch(
+            lambda c: calls.update(n=calls["n"] + 1),
+            check_timeout=0,
+            config_reloading=lambda: True,
+        )
+        assert calls["n"] == 0
+
+    def test_calls_callback_then_exits(self):
+        conn = _bare_connection()
+        calls = {"n": 0}
+
+        def reload():
+            return calls["n"] > 0
+
+        def cb(c):
+            calls["n"] += 1
+
+        conn.watch(cb, check_timeout=0, config_reloading=reload)
+        assert calls["n"] == 1

--- a/tests/test_mailbox_graph.py
+++ b/tests/test_mailbox_graph.py
@@ -1,0 +1,434 @@
+"""Tests for mailsuite.mailbox.graph.MSGraphConnection.
+
+The Graph SDK is fully mocked. We construct connections via __new__ and
+inject a fake fluent client so the code paths that touch the SDK can be
+exercised without real credentials or HTTP.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Skip everything if the optional [msgraph] extra isn't installed.
+pytest.importorskip("msgraph")
+pytest.importorskip("azure.identity")
+
+from mailsuite.mailbox import MailboxConnection  # noqa: E402
+from mailsuite.mailbox.graph import (  # noqa: E402
+    AuthMethod,
+    MSGraphConnection,
+    _generate_credential,
+    _run,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fluent SDK fake — mirrors the call chains MSGraphConnection actually uses
+# ---------------------------------------------------------------------------
+
+
+def _coro(value: Any):
+    """Wrap a value in an awaitable that returns it."""
+
+    async def _f():
+        return value
+
+    return _f()
+
+
+class FakeMessages:
+    def __init__(self):
+        self.posted = None
+        self.get_response = MagicMock()  # for create_folder calls? unused
+        self.get_calls = []
+        self.next_pages = []  # list of pages to return on subsequent .get / .with_url
+
+    def get(self, request_configuration=None):
+        self.get_calls.append(request_configuration)
+        if self.next_pages:
+            return _coro(self.next_pages.pop(0))
+        return _coro(None)
+
+    def with_url(self, url):
+        self._next_url = url
+        return self
+
+
+class FakeMailFolderItem:
+    def __init__(self, child_pages=None):
+        self.messages = FakeMessages()
+        self._child_pages = child_pages or []
+
+    def get(self, request_configuration=None):
+        return _coro(MagicMock(value=[MagicMock(id="folder123", display_name="x")]))
+
+    @property
+    def child_folders(self):
+        cf = MagicMock()
+
+        def _get(request_configuration=None):
+            if self._child_pages:
+                return _coro(self._child_pages.pop(0))
+            return _coro(MagicMock(value=[]))
+
+        cf.get = _get
+        cf.post = MagicMock(return_value=_coro(None))
+        return cf
+
+
+class FakeMailFolders:
+    def __init__(self):
+        self.posts = []
+        self._items: dict = {}
+        self._listing_pages = []
+
+    def by_mail_folder_id(self, fid):
+        if fid not in self._items:
+            self._items[fid] = FakeMailFolderItem()
+        return self._items[fid]
+
+    def get(self, request_configuration=None):
+        if self._listing_pages:
+            return _coro(self._listing_pages.pop(0))
+        return _coro(MagicMock(value=[]))
+
+    def post(self, body):
+        self.posts.append(body)
+        return _coro(None)
+
+
+class FakeMessageItem:
+    def __init__(self):
+        self.deleted = False
+        self.patched = None
+        self.moved_body = None
+        self.content = MagicMock()
+        self.content.get = MagicMock(return_value=_coro(b"raw rfc822 bytes"))
+        self.move = MagicMock()
+        self.move.post = MagicMock(side_effect=self._move_post)
+
+    def _move_post(self, body):
+        self.moved_body = body
+        return _coro(None)
+
+    def delete(self):
+        self.deleted = True
+        return _coro(None)
+
+    def patch(self, body):
+        self.patched = body
+        return _coro(None)
+
+
+class FakeUserMessages:
+    def __init__(self):
+        self.items: dict = {}
+
+    def by_message_id(self, mid):
+        if mid not in self.items:
+            self.items[mid] = FakeMessageItem()
+        return self.items[mid]
+
+
+class FakeSendMail:
+    def __init__(self):
+        self.last_body = None
+
+    def post(self, body):
+        self.last_body = body
+        return _coro(None)
+
+
+class FakeUserItem:
+    def __init__(self):
+        self.mail_folders = FakeMailFolders()
+        self.messages = FakeUserMessages()
+        self.send_mail = FakeSendMail()
+
+
+class FakeUsers:
+    def __init__(self):
+        self._user: FakeUserItem | None = None
+
+    def by_user_id(self, mailbox):
+        if self._user is None:
+            self._user = FakeUserItem()
+        return self._user
+
+
+class FakeGraphClient:
+    def __init__(self):
+        self.users = FakeUsers()
+
+
+def _make_conn() -> MSGraphConnection:
+    inst = MSGraphConnection.__new__(MSGraphConnection)
+    inst._client = FakeGraphClient()
+    inst.mailbox_name = "user@example.com"
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunHelper:
+    def test_runs_coroutine(self):
+        async def double():
+            return 42
+
+        assert _run(double()) == 42
+
+    def test_rejects_running_loop(self):
+        async def main():
+            with pytest.raises(RuntimeError, match="running event loop"):
+                _run(asyncio.sleep(0))
+
+        asyncio.run(main())
+
+
+class TestAuthMethodNames:
+    def test_enum_values(self):
+        assert AuthMethod.DeviceCode.name == "DeviceCode"
+        assert AuthMethod.ClientSecret.name == "ClientSecret"
+
+    def test_unknown_auth_method(self, tmp_path):
+        with pytest.raises(RuntimeError, match="not found"):
+            _generate_credential("BogusAuth", tmp_path / "tok")
+
+    def test_certificate_requires_path(self, tmp_path):
+        with pytest.raises(ValueError, match="certificate_path"):
+            _generate_credential(
+                AuthMethod.Certificate.name,
+                tmp_path / "tok",
+                client_id="c",
+                tenant_id="t",
+            )
+
+
+class TestSubclass:
+    def test_is_mailbox_connection(self):
+        assert issubclass(MSGraphConnection, MailboxConnection)
+
+
+class TestKeepalive:
+    def test_no_op(self):
+        _make_conn().keepalive()
+
+
+class TestSendMessage:
+    def test_send_with_plain_text(self):
+        from msgraph.generated.models.body_type import BodyType
+
+        conn = _make_conn()
+        conn.send_message(
+            message_from="ignored@example.com",
+            message_to=["b@example.org"],
+            subject="hi",
+            plain_message="hello",
+        )
+        body = conn._client.users.by_user_id("x").send_mail.last_body
+        assert body is not None
+        assert body.message.subject == "hi"
+        assert body.message.body.content_type == BodyType.Text
+        assert body.message.body.content == "hello"
+        assert body.save_to_sent_items is True
+
+    def test_send_with_html(self):
+        from msgraph.generated.models.body_type import BodyType
+
+        conn = _make_conn()
+        conn.send_message(
+            message_from="x@example.com",
+            message_to=["b@example.org"],
+            subject="hi",
+            html_message="<p>hi</p>",
+        )
+        body = conn._client.users.by_user_id("x").send_mail.last_body
+        assert body.message.body.content_type == BodyType.Html
+        assert body.message.body.content == "<p>hi</p>"
+
+    def test_send_with_recipients(self):
+        conn = _make_conn()
+        conn.send_message(
+            message_from="x@example.com",
+            message_to=["a@e.com", "b@e.com"],
+            message_cc=["c@e.com"],
+            message_bcc=["d@e.com"],
+            plain_message="hi",
+        )
+        body = conn._client.users.by_user_id("x").send_mail.last_body
+        assert len(body.message.to_recipients) == 2
+        assert len(body.message.cc_recipients) == 1
+        assert len(body.message.bcc_recipients) == 1
+        assert body.message.to_recipients[0].email_address.address == "a@e.com"
+
+    def test_send_with_attachments(self):
+        conn = _make_conn()
+        conn.send_message(
+            message_from="x@example.com",
+            message_to=["b@example.org"],
+            plain_message="hi",
+            attachments=[("readme.txt", b"contents")],
+        )
+        body = conn._client.users.by_user_id("x").send_mail.last_body
+        assert len(body.message.attachments) == 1
+        att = body.message.attachments[0]
+        assert att.name == "readme.txt"
+        assert att.content_bytes == b"contents"
+
+
+class TestMessageOps:
+    def test_fetch_message(self):
+        conn = _make_conn()
+        result = conn.fetch_message("msg42")
+        assert result == "raw rfc822 bytes"
+
+    def test_fetch_message_str_passthrough(self):
+        conn = _make_conn()
+        # Patch content.get to return a str directly
+        item = conn._client.users.by_user_id("x").messages.by_message_id("m1")
+        item.content.get = MagicMock(return_value=_coro("already a string"))
+        assert conn.fetch_message("m1") == "already a string"
+
+    def test_fetch_message_none_returns_empty(self):
+        conn = _make_conn()
+        item = conn._client.users.by_user_id("x").messages.by_message_id("m2")
+        item.content.get = MagicMock(return_value=_coro(None))
+        assert conn.fetch_message("m2") == ""
+
+    def test_fetch_message_mark_read(self):
+        conn = _make_conn()
+        conn.fetch_message("m3", mark_read=True)
+        item = conn._client.users.by_user_id("x").messages.by_message_id("m3")
+        # patched = Message(is_read=True)
+        assert item.patched is not None
+        assert item.patched.is_read is True
+
+    def test_mark_message_read(self):
+        conn = _make_conn()
+        conn.mark_message_read("m4")
+        item = conn._client.users.by_user_id("x").messages.by_message_id("m4")
+        assert item.patched is not None
+
+    def test_delete_message(self):
+        conn = _make_conn()
+        conn.delete_message("m5")
+        item = conn._client.users.by_user_id("x").messages.by_message_id("m5")
+        assert item.deleted is True
+
+
+class TestFolderResolution:
+    def test_finds_folder_by_display_name(self):
+        conn = _make_conn()
+        conn._client.users.by_user_id("x").mail_folders._listing_pages = [
+            MagicMock(value=[MagicMock(id="abc123", display_name="Reports")]),
+        ]
+        assert conn._find_folder_id_from_folder_path("Reports") == "abc123"
+
+    def test_unknown_folder_raises(self):
+        conn = _make_conn()
+        conn._client.users.by_user_id("x").mail_folders._listing_pages = [
+            MagicMock(value=[]),
+        ]
+        with pytest.raises(RuntimeError, match="not found"):
+            conn._find_folder_id_from_folder_path("DoesNotExist")
+
+    def test_well_known_folder_fallback(self):
+        conn = _make_conn()
+        # Empty listing for the literal name…
+        conn._client.users.by_user_id("x").mail_folders._listing_pages = [
+            MagicMock(value=[]),
+        ]
+        # …but the well-known alias 'inbox' resolves
+        item = conn._client.users.by_user_id("x").mail_folders.by_mail_folder_id(
+            "inbox"
+        )
+
+        async def _inbox_get(request_configuration=None):
+            return MagicMock(id="inbox-id")
+
+        item.get = lambda request_configuration=None: _inbox_get(request_configuration)
+        assert conn._find_folder_id_from_folder_path("Inbox") == "inbox-id"
+
+
+class TestCreateFolder:
+    def test_top_level_folder(self):
+        conn = _make_conn()
+        conn.create_folder("Reports")
+        # Posted body has the right display name
+        posts = conn._client.users.by_user_id("x").mail_folders.posts
+        assert len(posts) == 1
+        assert posts[0].display_name == "Reports"
+
+    def test_already_exists_swallowed(self):
+        conn = _make_conn()
+        # Make post raise an "already exists" error
+        async def _raise(*a, **k):
+            raise RuntimeError("ErrorFolderExists: yep")
+
+        conn._client.users.by_user_id("x").mail_folders.post = lambda body: _raise()
+        # Should not raise
+        conn.create_folder("Reports")
+
+    def test_unknown_error_propagates(self):
+        conn = _make_conn()
+
+        async def _raise(*a, **k):
+            raise RuntimeError("server explosion")
+
+        conn._client.users.by_user_id("x").mail_folders.post = lambda body: _raise()
+        with pytest.raises(RuntimeError, match="explosion"):
+            conn.create_folder("Reports")
+
+
+class TestFetchMessagesPagination:
+    def test_single_page(self):
+        conn = _make_conn()
+        # Folder lookup returns an id directly (no pagination)
+        conn._client.users.by_user_id("x").mail_folders._listing_pages = [
+            MagicMock(value=[MagicMock(id="f1", display_name="Reports")]),
+        ]
+        # Messages page
+        item = conn._client.users.by_user_id("x").mail_folders.by_mail_folder_id("f1")
+        item.messages.next_pages = [
+            MagicMock(
+                value=[MagicMock(id="m1"), MagicMock(id="m2")],
+                odata_next_link=None,
+            )
+        ]
+        ids = conn.fetch_messages("Reports")
+        assert ids == ["m1", "m2"]
+
+
+class TestWatch:
+    def test_exits_on_config_reload(self):
+        conn = _make_conn()
+        calls = {"n": 0}
+        conn.watch(
+            lambda c: calls.update(n=calls["n"] + 1),
+            check_timeout=0,
+            config_reloading=lambda: True,
+        )
+        assert calls["n"] == 0
+
+    def test_calls_callback_then_exits(self):
+        conn = _make_conn()
+        calls = {"n": 0}
+
+        def cb(c):
+            calls["n"] += 1
+
+        # The watch loop checks reload twice per iteration, callback runs in
+        # between. We want both checks of iter 1 to return False (callback
+        # runs) and the first check of iter 2 to return True (loop exits).
+        def reload():
+            return calls["n"] > 0
+
+        conn.watch(cb, check_timeout=0, config_reloading=reload)
+        assert calls["n"] == 1

--- a/tests/test_mailbox_imap.py
+++ b/tests/test_mailbox_imap.py
@@ -1,0 +1,85 @@
+"""Tests for mailsuite.mailbox.imap.IMAPConnection."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from imapclient.exceptions import IMAPClientError
+
+from mailsuite.mailbox.imap import IMAPConnection
+
+
+def _bare_connection() -> IMAPConnection:
+    """Construct an IMAPConnection without doing IMAP I/O."""
+    inst = IMAPConnection.__new__(IMAPConnection)
+    inst._username = "user"
+    inst._password = "pw"
+    inst._verify = True
+    inst._client = MagicMock()
+    return inst
+
+
+class TestIMAPConnection:
+    def test_create_folder_delegates(self):
+        conn = _bare_connection()
+        conn.create_folder("Reports")
+        conn._client.create_folder.assert_called_once_with("Reports")
+
+    def test_fetch_messages_no_since(self):
+        conn = _bare_connection()
+        conn._client.search.return_value = [1, 2, 3]
+        result = conn.fetch_messages("INBOX")
+        conn._client.select_folder.assert_called_once_with("INBOX")
+        conn._client.search.assert_called_once_with()
+        assert result == [1, 2, 3]
+
+    def test_fetch_messages_since(self):
+        conn = _bare_connection()
+        conn._client.search.return_value = [9]
+        conn.fetch_messages("INBOX", since="01-Jan-2026")
+        conn._client.search.assert_called_once_with("SINCE 01-Jan-2026")
+
+    def test_fetch_message(self):
+        conn = _bare_connection()
+        conn._client.fetch_message.return_value = "raw msg"
+        assert conn.fetch_message(42) == "raw msg"
+        conn._client.fetch_message.assert_called_once_with(42, parse=False)
+
+    def test_delete_message(self):
+        conn = _bare_connection()
+        conn.delete_message(42)
+        conn._client.delete_messages.assert_called_once_with([42])
+
+    def test_delete_message_fallback(self, caplog):
+        conn = _bare_connection()
+        conn._client.delete_messages.side_effect = IMAPClientError("server angry")
+        conn.delete_message(42)
+        # Falls back to add_flags + expunge
+        conn._client.add_flags.assert_called_once_with(
+            [42], [r"\Deleted"], silent=True
+        )
+        conn._client.expunge.assert_called_once()
+
+    def test_move_message(self):
+        conn = _bare_connection()
+        conn.move_message(42, "Archive")
+        conn._client.move_messages.assert_called_once_with([42], "Archive")
+
+    def test_move_message_fallback(self):
+        conn = _bare_connection()
+        conn._client.move_messages.side_effect = IMAPClientError("nope")
+        conn.move_message(42, "Archive")
+        # Falls back to copy + delete
+        conn._client.copy.assert_called_once_with([42], "Archive")
+        conn._client.delete_messages.assert_called_once_with([42])
+
+    def test_keepalive_calls_noop(self):
+        conn = _bare_connection()
+        conn.keepalive()
+        conn._client.noop.assert_called_once()
+
+    def test_send_message_raises(self):
+        conn = _bare_connection()
+        with pytest.raises(NotImplementedError, match="IMAP"):
+            conn.send_message("a@example.com")

--- a/tests/test_mailbox_maildir.py
+++ b/tests/test_mailbox_maildir.py
@@ -1,0 +1,172 @@
+"""Tests for mailsuite.mailbox.maildir."""
+
+from __future__ import annotations
+
+import mailbox
+import os
+
+import pytest
+
+from mailsuite.mailbox import MailboxConnection, MaildirConnection
+
+
+@pytest.fixture
+def maildir_path(tmp_path):
+    md = tmp_path / "Maildir"
+    md.mkdir()
+    return str(md)
+
+
+class TestMaildirConnection:
+    def test_subclasses_mailbox_connection(self):
+        assert issubclass(MaildirConnection, MailboxConnection)
+
+    def test_create_with_subdirs(self, maildir_path):
+        MaildirConnection(maildir_path, maildir_create=True)
+        for sub in ("cur", "new", "tmp"):
+            assert os.path.isdir(os.path.join(maildir_path, sub))
+
+    def test_create_folder(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        conn.create_folder("Reports")
+        # subfolder is stored under .Reports per Maildir++ convention
+        assert os.path.isdir(os.path.join(maildir_path, ".Reports"))
+
+    def test_fetch_messages_inbox(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        box = mailbox.Maildir(maildir_path)
+        msg = mailbox.MaildirMessage(b"From: a\r\nSubject: t\r\n\r\nbody\r\n")
+        msg.add_flag("S")
+        key = box.add(msg)
+        assert key in conn.fetch_messages("INBOX")
+        assert key in conn.fetch_messages("")
+
+    def test_fetch_messages_subfolder(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        conn.create_folder("Reports")
+        box = mailbox.Maildir(maildir_path)
+        folder = box.get_folder("Reports")
+        msg = mailbox.MaildirMessage(b"From: a\r\nSubject: t\r\n\r\nbody\r\n")
+        msg.add_flag("S")
+        key = folder.add(msg)
+        assert key in conn.fetch_messages("Reports")
+
+    def test_fetch_message(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        conn.create_folder("Reports")
+        box = mailbox.Maildir(maildir_path)
+        folder = box.get_folder("Reports")
+        msg = mailbox.MaildirMessage(b"From: a\r\nSubject: hi\r\n\r\nbody\r\n")
+        msg.add_flag("S")
+        key = folder.add(msg)
+        conn.fetch_messages("Reports")  # selects active folder
+        raw = conn.fetch_message(key)
+        assert "Subject: hi" in raw
+        assert "body" in raw
+
+    def test_fetch_message_missing_returns_empty(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        conn.fetch_messages("INBOX")
+        assert conn.fetch_message("does-not-exist") == ""
+
+    def test_fetch_message_marks_read(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        conn.create_folder("Reports")
+        box = mailbox.Maildir(maildir_path)
+        folder = box.get_folder("Reports")
+        msg = mailbox.MaildirMessage(b"From: a\r\nSubject: t\r\n\r\nbody\r\n")
+        # message starts in new/
+        msg.set_subdir("new")
+        key = folder.add(msg)
+        conn.fetch_messages("Reports")
+        conn.fetch_message(key, mark_read=True)
+        # after fetch with mark_read, message is in cur/ with S flag
+        refetched = mailbox.Maildir(maildir_path).get_folder("Reports")[key]
+        assert refetched.get_subdir() == "cur"
+        assert "S" in refetched.get_flags()
+
+    def test_delete_message(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        box = mailbox.Maildir(maildir_path)
+        msg = mailbox.MaildirMessage(b"From: a\r\nSubject: t\r\n\r\nbody\r\n")
+        msg.add_flag("S")
+        key = box.add(msg)
+        conn.fetch_messages("INBOX")
+        conn.delete_message(key)
+        assert key not in conn.fetch_messages("INBOX")
+
+    def test_move_message(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        conn.create_folder("Archive")
+        box = mailbox.Maildir(maildir_path)
+        msg = mailbox.MaildirMessage(b"From: a\r\nSubject: t\r\n\r\nbody\r\n")
+        msg.add_flag("S")
+        key = box.add(msg)
+        conn.fetch_messages("INBOX")
+        conn.move_message(key, "Archive")
+        # gone from inbox, present in archive
+        assert key not in conn.fetch_messages("INBOX")
+        archive_keys = conn.fetch_messages("Archive")
+        assert len(archive_keys) == 1
+
+    def test_move_missing_message_no_op(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        conn.create_folder("Archive")
+        conn.fetch_messages("INBOX")
+        # Should not raise even when the message ID doesn't exist
+        conn.move_message("missing", "Archive")
+
+    def test_keepalive_no_op(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        # Just verify it doesn't raise
+        conn.keepalive()
+
+    def test_send_raises(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        with pytest.raises(NotImplementedError, match="Maildir"):
+            conn.send_message("a@example.com", ["b@example.org"])
+
+    def test_watch_exits_on_config_reload(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        calls = {"n": 0}
+
+        def reload():
+            return True
+
+        # Should exit immediately without calling check_callback
+        conn.watch(lambda c: calls.update(n=calls["n"] + 1), check_timeout=1, config_reloading=reload)
+        assert calls["n"] == 0
+
+    def test_watch_calls_callback(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        calls = {"n": 0}
+        flag = {"reload": False}
+
+        def reload():
+            # First check returns False so the callback runs;
+            # after the callback we flip and exit.
+            if calls["n"] >= 1:
+                flag["reload"] = True
+            return flag["reload"]
+
+        def cb(c):
+            calls["n"] += 1
+
+        conn.watch(cb, check_timeout=0, config_reloading=reload)
+        assert calls["n"] == 1
+
+    def test_watch_callback_exception_logged(self, maildir_path):
+        conn = MaildirConnection(maildir_path, maildir_create=True)
+        flag = {"first": True}
+
+        def reload():
+            if flag["first"]:
+                flag["first"] = False
+                return False
+            return True
+
+        def cb(c):
+            raise RuntimeError("boom")
+
+        # Should log warning and exit cleanly without re-raising
+        conn.watch(cb, check_timeout=0, config_reloading=reload)

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -1,0 +1,261 @@
+"""Tests for mailsuite.smtp.send_email.
+
+The actual network/SMTP I/O is exercised by patching smtplib.SMTP and
+smtplib.SMTP_SSL with fakes. We focus on the dispatch logic — DKIM
+wiring, envelope/header construction, error wrapping — rather than
+re-testing smtplib itself.
+"""
+
+from __future__ import annotations
+
+import smtplib
+import socket
+import ssl
+
+import dkim as _dkim
+import pytest
+
+from mailsuite import smtp as ms_smtp
+from mailsuite.dkim import generate_dkim_txt_record
+from mailsuite.smtp import SMTPError, send_email
+
+
+class FakeSMTPServer:
+    """A minimal stand-in for smtplib.SMTP / SMTP_SSL."""
+
+    instances: list = []
+
+    def __init__(
+        self, host="", port=0, *args, has_starttls=True, **kwargs
+    ):
+        self.host = host
+        self.port = port
+        self._has_starttls = has_starttls
+        self.connected = False
+        self.starttls_called = False
+        self.ehlo_count = 0
+        self.login_args = None
+        self.sendmail_args = None
+        FakeSMTPServer.instances.append(self)
+
+    def connect(self, host, port):
+        self.connected = True
+        self.host = host
+        self.port = port
+
+    def ehlo_or_helo_if_needed(self):
+        self.ehlo_count += 1
+
+    def ehlo(self):
+        self.ehlo_count += 1
+
+    def has_extn(self, name):
+        return name.lower() == "starttls" and self._has_starttls
+
+    def starttls(self, context=None):
+        self.starttls_called = True
+
+    def login(self, user, password):
+        self.login_args = (user, password)
+
+    def sendmail(self, sender, to, body):
+        self.sendmail_args = (sender, list(to), body)
+
+
+@pytest.fixture
+def fake_smtp(monkeypatch):
+    FakeSMTPServer.instances = []
+    monkeypatch.setattr(smtplib, "SMTP", FakeSMTPServer)
+    monkeypatch.setattr(smtplib, "SMTP_SSL", FakeSMTPServer)
+    monkeypatch.setattr(ms_smtp.smtplib, "SMTP", FakeSMTPServer)
+    monkeypatch.setattr(ms_smtp.smtplib, "SMTP_SSL", FakeSMTPServer)
+    return FakeSMTPServer
+
+
+class TestSendEmailBasic:
+    def test_sends_message(self, fake_smtp):
+        send_email(
+            host="smtp.example.com",
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            subject="hi",
+            plain_message="hello",
+        )
+        srv = fake_smtp.instances[-1]
+        assert srv.connected
+        assert srv.sendmail_args is not None
+        sender, recipients, body = srv.sendmail_args
+        assert sender == "a@example.com"
+        assert "b@example.org" in recipients
+        assert "Subject: hi" in body
+        assert "hello" in body
+
+    def test_login_when_credentials_provided(self, fake_smtp):
+        send_email(
+            host="smtp.example.com",
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            username="user",
+            password="pw",
+        )
+        srv = fake_smtp.instances[-1]
+        assert srv.login_args == ("user", "pw")
+
+    def test_starttls_used_when_supported(self, fake_smtp):
+        send_email(
+            host="smtp.example.com",
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+        )
+        srv = fake_smtp.instances[-1]
+        assert srv.starttls_called is True
+
+    def test_no_starttls_when_unsupported(self, fake_smtp, monkeypatch):
+        # Fake SMTP that says STARTTLS isn't available
+        def _no_starttls(*args, **kwargs):
+            return FakeSMTPServer(*args, has_starttls=False, **kwargs)
+
+        monkeypatch.setattr(smtplib, "SMTP", _no_starttls)
+        monkeypatch.setattr(ms_smtp.smtplib, "SMTP", _no_starttls)
+        send_email(
+            host="smtp.example.com",
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+        )
+        srv = fake_smtp.instances[-1]
+        assert srv.starttls_called is False
+
+    def test_require_encryption_uses_smtp_ssl(self, fake_smtp):
+        send_email(
+            host="smtp.example.com",
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            require_encryption=True,
+        )
+        # SMTP_SSL was called with our fake — connection happens but starttls
+        # isn't called when require_encryption is True
+        srv = fake_smtp.instances[-1]
+        assert srv.connected
+        assert srv.starttls_called is False
+
+    def test_envelope_from_overrides(self, fake_smtp):
+        send_email(
+            host="smtp.example.com",
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            envelope_from="bounce@example.com",
+        )
+        sender, _, _ = fake_smtp.instances[-1].sendmail_args
+        assert sender == "bounce@example.com"
+
+    def test_cc_and_bcc_in_envelope(self, fake_smtp):
+        send_email(
+            host="smtp.example.com",
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            message_cc=["c@example.org"],
+            message_bcc=["d@example.org"],
+        )
+        _, recipients, body = fake_smtp.instances[-1].sendmail_args
+        # Cc must appear in the envelope (not necessarily in the To header)
+        assert "c@example.org" in recipients or "c@example.org" in body
+
+
+class TestSendEmailDKIM:
+    def test_dkim_signs_message(self, fake_smtp, dkim_keypair):
+        priv, pub = dkim_keypair
+        send_email(
+            host="smtp.example.com",
+            message_from="Sender <sender@example.com>",
+            message_to=["b@example.org"],
+            subject="hi",
+            plain_message="hello",
+            dkim_private_key=priv,
+            dkim_selector="ms1",
+        )
+        _, _, body = fake_smtp.instances[-1].sendmail_args
+        assert body.startswith("DKIM-Signature: ")
+
+        record = generate_dkim_txt_record(pub).encode()
+
+        def fake_dns(name, timeout=5):
+            return record
+
+        assert _dkim.verify(body.encode(), dnsfunc=fake_dns) is True
+
+    def test_dkim_explicit_domain(self, fake_smtp, dkim_keypair):
+        priv, _ = dkim_keypair
+        send_email(
+            host="smtp.example.com",
+            message_from="sender@inferred.example",
+            message_to=["b@example.org"],
+            dkim_private_key=priv,
+            dkim_selector="ms1",
+            dkim_domain="explicit.example",
+            plain_message="hi",
+        )
+        _, _, body = fake_smtp.instances[-1].sendmail_args
+        assert "d=explicit.example" in body
+
+    def test_missing_selector_raises(self, fake_smtp, dkim_keypair):
+        priv, _ = dkim_keypair
+        with pytest.raises(ValueError, match="dkim_selector"):
+            send_email(
+                host="smtp.example.com",
+                message_from="a@example.com",
+                message_to=["b@example.org"],
+                dkim_private_key=priv,
+            )
+
+    def test_unparseable_from_for_domain_raises(self, fake_smtp, dkim_keypair):
+        priv, _ = dkim_keypair
+        with pytest.raises(ValueError, match="dkim_domain"):
+            send_email(
+                host="smtp.example.com",
+                message_from="no-at-sign",
+                message_to=["b@example.org"],
+                dkim_private_key=priv,
+                dkim_selector="ms1",
+            )
+
+
+class TestSendEmailErrors:
+    def test_smtp_exception_wrapped(self, monkeypatch):
+        class BoomServer(FakeSMTPServer):
+            def sendmail(self, *a, **k):
+                raise smtplib.SMTPException("550 mailbox unavailable.")
+
+        monkeypatch.setattr(smtplib, "SMTP", BoomServer)
+        monkeypatch.setattr(ms_smtp.smtplib, "SMTP", BoomServer)
+        with pytest.raises(SMTPError, match="mailbox unavailable"):
+            send_email(
+                host="smtp.example.com",
+                message_from="a@example.com",
+                message_to=["b@example.org"],
+            )
+
+    @pytest.mark.parametrize(
+        ("exc", "match"),
+        [
+            (socket.gaierror(), "DNS"),
+            (ConnectionRefusedError(), "refused"),
+            (ConnectionResetError(), "reset"),
+            (ConnectionAbortedError(), "aborted"),
+            (TimeoutError(), "timed out"),
+            (ssl.SSLError("boom"), "SSL"),
+            (ssl.CertificateError("bad cert"), "Certificate"),
+        ],
+    )
+    def test_connection_errors_wrapped(self, monkeypatch, exc, match):
+        class BoomServer(FakeSMTPServer):
+            def connect(self, host, port):
+                raise exc
+
+        monkeypatch.setattr(smtplib, "SMTP", BoomServer)
+        monkeypatch.setattr(ms_smtp.smtplib, "SMTP", BoomServer)
+        with pytest.raises(SMTPError, match=match):
+            send_email(
+                host="smtp.example.com",
+                message_from="a@example.com",
+                message_to=["b@example.org"],
+            )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,305 @@
+"""Tests for mailsuite.utils."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from mailsuite.utils import (
+    create_email,
+    decode_base64,
+    get_filename_safe_string,
+    is_outlook_msg,
+    parse_authentication_results,
+    parse_dkim_signature,
+    parse_email,
+    parse_email_address,
+    from_trusted_domain,
+)
+
+
+class TestDecodeBase64:
+    def test_padded(self):
+        assert decode_base64("aGVsbG8=") == b"hello"
+
+    def test_unpadded(self):
+        assert decode_base64("aGVsbG8") == b"hello"
+
+    def test_empty(self):
+        assert decode_base64("") == b""
+
+    def test_unicode_payload(self):
+        encoded = base64.b64encode("héllo".encode()).decode().rstrip("=")
+        assert decode_base64(encoded) == "héllo".encode()
+
+
+class TestGetFilenameSafeString:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("hello world", "hello world"),
+            ("a/b\\c:d*e?f<g>h|i", "abcdefghi"),
+            ("with\nnewlines\rhere", "withnewlineshere"),
+            ('"quoted"', "quoted"),
+            ("trailing.", "trailing"),
+        ],
+    )
+    def test_invalid_chars(self, raw, expected):
+        assert get_filename_safe_string(raw) == expected
+
+    def test_truncation(self):
+        s = "x" * 300
+        assert get_filename_safe_string(s, max_length=50) == "x" * 50
+
+    def test_none_becomes_string(self):
+        assert get_filename_safe_string(None) == "None"
+
+
+class TestParseEmailAddress:
+    def test_string_with_display_name(self):
+        result = parse_email_address("Alice <alice@example.com>")
+        assert result["display_name"] == "Alice"
+        assert result["address"] == "alice@example.com"
+        assert result["local"] == "alice"
+        assert result["domain"] == "example.com"
+        assert result["sld"] == "example.com"
+        assert result["compliant"] is True
+
+    def test_bare_address(self):
+        result = parse_email_address("alice@example.com")
+        assert result["display_name"] is None
+        assert result["address"] == "alice@example.com"
+        assert result["domain"] == "example.com"
+        assert result["compliant"] is True
+
+    def test_tuple_input(self):
+        result = parse_email_address(("Alice", "alice@example.com"))
+        assert result["display_name"] == "Alice"
+        assert result["domain"] == "example.com"
+
+    def test_subdomain_sld(self):
+        result = parse_email_address("user@mail.sub.example.co.uk")
+        assert result["domain"] == "mail.sub.example.co.uk"
+        assert result["sld"] == "example.co.uk"
+
+    def test_uppercase_normalized(self):
+        result = parse_email_address("USER@EXAMPLE.COM")
+        assert result["local"] == "user"
+        assert result["domain"] == "example.com"
+
+    def test_non_compliant_recovery(self):
+        # parseaddr returns ("","") on garbage; we fall back to manual split
+        result = parse_email_address("garbage <weird@@example.com>")
+        assert result["compliant"] is False or result["address"] != ""
+
+
+class TestIsOutlookMsg:
+    def test_recognises_ole_signature(self):
+        ole = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"\x00" * 24
+        assert is_outlook_msg(ole) is True
+
+    def test_rejects_plain_text(self):
+        assert is_outlook_msg(b"From: a@b.c\r\n\r\nbody") is False
+
+    def test_rejects_non_bytes(self):
+        assert is_outlook_msg("string-not-bytes") is False  # type: ignore[arg-type]
+
+
+class TestCreateEmail:
+    def test_minimal(self):
+        msg = create_email(message_from="a@example.com", message_to=["b@example.org"])
+        assert "From: a@example.com" in msg
+        assert "To: b@example.org" in msg
+        assert "Date: " in msg
+
+    def test_subject_and_bodies(self):
+        msg = create_email(
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            subject="Hi",
+            plain_message="plain body",
+            html_message="<p>html body</p>",
+        )
+        assert "Subject: Hi" in msg
+        assert "plain body" in msg
+        assert "<p>html body</p>" in msg
+
+    def test_cc_recipients(self):
+        msg = create_email(
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            message_cc=["c@example.org", "d@example.org"],
+        )
+        assert "Cc: c@example.org, d@example.org" in msg
+
+    def test_custom_headers(self):
+        msg = create_email(
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            message_headers={"X-Custom": "yes", "List-Unsubscribe": "<mailto:u@x>"},
+        )
+        assert "X-Custom: yes" in msg
+        assert "List-Unsubscribe: <mailto:u@x>" in msg
+
+    def test_attachments(self):
+        msg = create_email(
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            attachments=[("hello.txt", b"hello world")],
+        )
+        # multipart with the attachment present
+        assert "hello.txt" in msg
+        assert 'Content-Disposition: attachment; filename="hello.txt"' in msg
+
+
+class TestParseEmail:
+    def test_basic_message(self, sample_email_str):
+        parsed = parse_email(sample_email_str)
+        assert parsed["from"]["address"] == "sender@example.com"
+        assert parsed["from"]["domain"] == "example.com"
+        assert parsed["subject"] == "Hello"
+        assert parsed["to"][0]["address"] == "recipient@example.org"
+        assert parsed["body"].strip() == "Hello world"
+        assert parsed["filename_safe_subject"] == "Hello"
+        assert parsed["automatic_reply"] is False
+
+    def test_bytes_input(self, sample_email_str):
+        parsed = parse_email(sample_email_str.encode())
+        assert parsed["subject"] == "Hello"
+
+    def test_invalid_input_type(self):
+        with pytest.raises(TypeError):
+            parse_email(12345)  # type: ignore[arg-type]
+
+    def test_html_body_extracted(self):
+        raw = (
+            "From: a@example.com\r\n"
+            "To: b@example.org\r\n"
+            "Subject: HTML test\r\n"
+            "Content-Type: text/html\r\n"
+            "\r\n"
+            "<p>Hello <b>world</b></p>\r\n"
+        )
+        parsed = parse_email(raw)
+        assert "Hello" in parsed["body"]
+        assert "Hello" in parsed["body_markdown"]
+
+    def test_automatic_reply_detection(self):
+        raw = (
+            "From: a@example.com\r\n"
+            "To: b@example.org\r\n"
+            "Subject: Out of office\r\n"
+            "X-Auto-Response-Suppress: All\r\n"
+            "Auto-Submitted: auto_generated\r\n"
+            "\r\n"
+            "I'm away.\r\n"
+        )
+        parsed = parse_email(raw)
+        assert parsed["automatic_reply"] is True
+
+
+class TestParseAuthenticationResults:
+    def test_string_input(self):
+        header = (
+            "mx.example.com; spf=pass smtp.mailfrom=user@example.com; "
+            "dkim=pass header.d=example.com; dmarc=pass header.from=example.com"
+        )
+        result = parse_authentication_results(header)
+        assert isinstance(result, dict)
+        assert result["spf"]["result"] == "pass"
+        assert result["dkim"]["result"] == "pass"
+        assert result["dkim"]["header.d"] == "example.com"
+        assert result["dmarc"]["result"] == "pass"
+
+    def test_list_input(self):
+        headers = [
+            "mx.example.com; spf=pass smtp.mailfrom=user@example.com",
+            "mx.example.com; dkim=pass header.d=example.com",
+        ]
+        results = parse_authentication_results(headers)
+        assert isinstance(results, list)
+        assert len(results) == 2
+
+    def test_dmarc_header_from_inferred(self):
+        header = "mx.example.com; dmarc=pass action=none"
+        result = parse_authentication_results(header, from_domain="example.com")
+        assert result["dmarc"]["header.from"] == "example.com"
+        assert result["dmarc"]["disp"] == "none"
+
+    def test_invalid_input(self):
+        with pytest.raises(ValueError):
+            parse_authentication_results(123)  # type: ignore[arg-type]
+
+
+class TestParseDkimSignature:
+    def test_string_input(self):
+        sig = (
+            "v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com; "
+            "s=ms1; h=From:To:Subject; bh=abc; b=def"
+        )
+        parsed = parse_dkim_signature(sig)
+        assert isinstance(parsed, dict)
+        assert parsed["d"] == "example.com"
+        assert parsed["s"] == "ms1"
+        assert parsed["h"] == ["From", "To", "Subject"]
+
+    def test_list_input(self):
+        sigs = [
+            "v=1; d=example.com; s=ms1; h=From",
+            "v=1; d=example.org; s=ms2; h=From",
+        ]
+        parsed = parse_dkim_signature(sigs)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2
+
+    def test_folded_header(self):
+        # Headers may be wrapped onto multiple lines
+        sig = "v=1; a=rsa-sha256;\r\n  d=example.com; s=ms1"
+        parsed = parse_dkim_signature(sig)
+        assert isinstance(parsed, dict)
+        assert parsed["d"] == "example.com"
+
+    def test_invalid_input(self):
+        with pytest.raises(ValueError):
+            parse_dkim_signature(123)  # type: ignore[arg-type]
+
+
+class TestFromTrustedDomain:
+    def _msg_with_dmarc_pass(self, domain: str = "example.com") -> str:
+        return (
+            f"From: a@{domain}\r\n"
+            "To: b@example.org\r\n"
+            f"Authentication-Results: mx.example.org; dkim=pass header.d={domain}; "
+            f"dmarc=pass header.from={domain}\r\n"
+            "Subject: hi\r\n\r\nbody\r\n"
+        )
+
+    def test_trusted_exact(self):
+        msg = self._msg_with_dmarc_pass("example.com")
+        assert from_trusted_domain(msg, ["example.com"]) is True
+
+    def test_untrusted(self):
+        msg = self._msg_with_dmarc_pass("evil.example")
+        assert from_trusted_domain(msg, ["example.com"]) is False
+
+    def test_sld_match(self):
+        msg = self._msg_with_dmarc_pass("mail.example.com")
+        assert from_trusted_domain(msg, ["example.com"], include_sld=True) is True
+
+    def test_sld_disabled(self):
+        msg = self._msg_with_dmarc_pass("mail.example.com")
+        assert from_trusted_domain(msg, ["example.com"], include_sld=False) is False
+
+    def test_string_trusted_domains(self):
+        msg = self._msg_with_dmarc_pass("example.com")
+        assert from_trusted_domain(msg, "example.com") is True
+
+    def test_no_auth_header(self):
+        msg = "From: a@example.com\r\nSubject: x\r\n\r\nbody\r\n"
+        assert from_trusted_domain(msg, ["example.com"]) is False
+
+    def test_already_parsed_dict(self):
+        msg = self._msg_with_dmarc_pass("example.com")
+        parsed = parse_email(msg)
+        assert from_trusted_domain(parsed, ["example.com"]) is True


### PR DESCRIPTION
## Summary

This PR does three things:

1. **Releases 2.0.0** — consolidates the unreleased 1.12.0 (DKIM module) and 1.13.0 (mailbox abstraction) changelog entries into a single major-release entry, bumps `__version__` to `2.0.0`.

2. **Adds a comprehensive `pytest` test suite** covering every module shipped in the package — 205 tests, 70% line coverage with branch coverage, with the network-bound paths (real IMAP, OAuth flows, msgconvert subprocess, query_dns) being the only meaningful gaps. Test files mirror module layout under [tests/](tests/):
   - [test_utils.py](tests/test_utils.py) — 45 tests: parsing, address handling, header parsing, DKIM-Signature/Authentication-Results parsing, trusted-domain checks
   - [test_dkim.py](tests/test_dkim.py) — 34 tests: key generation, TXT records, full round-trip signing+verification including multi-signature and tampering scenarios
   - [test_smtp.py](tests/test_smtp.py) — 19 tests: full `send_email` dispatch (DKIM wiring, STARTTLS branching, login, all error-wrapping paths) with `smtplib` stubbed out
   - [test_imap.py](tests/test_imap.py) — 25 tests: fetch retry/fallback logic, delete/move chunking, folder normalization, with `imapclient` mocked
   - [test_mailbox_base.py](tests/test_mailbox_base.py) + [test_mailbox_imap.py](tests/test_mailbox_imap.py) + [test_mailbox_maildir.py](tests/test_mailbox_maildir.py) + [test_mailbox_graph.py](tests/test_mailbox_graph.py) + [test_mailbox_gmail.py](tests/test_mailbox_gmail.py) — 82 tests for the ABC plus all four backends, including `send_message`, watch loops, folder resolution, pagination, and error paths
   - Maildir uses a real filesystem; the cloud backends use mocked SDKs; the IMAP backend uses a mocked `IMAPClient`
   - The `[msgraph]` and `[gmail]` extras are auto-skipped in CI when not installed via `pytest.importorskip`

   Module-by-module coverage:

   | Module | Coverage |
   |---|---|
   | `mailsuite.dkim` | 97% |
   | `mailsuite.smtp` | 95% |
   | `mailsuite.mailbox.base` | 100% |
   | `mailsuite.mailbox.maildir` | 84% |
   | `mailsuite.mailbox.gmail` | 79% |
   | `mailsuite.mailbox.graph` | 69% |
   | `mailsuite.utils` | 67% |
   | `mailsuite.mailbox.imap` | 63% |
   | `mailsuite.imap` | 52% |
   | **Overall** | **70%** |

   Untested code is dominated by network/subprocess I/O (`IMAPClient.__init__` socket setup, `_start_idle` loop, `convert_outlook_msg`'s `msgconvert` call, `query_dns`, `_get_creds` OAuth flow) — those need integration-test infrastructure rather than mocks.

3. **Adds a GitHub Actions CI workflow** at [.github/workflows/ci.yml](.github/workflows/ci.yml):
   - `lint` job: `ruff check` + `pyright` (latest, per the lesson from the DKIM PR)
   - `test` matrix: pytest with coverage across Python 3.9, 3.10, 3.11, 3.12, 3.13
   - Coverage uploaded to Codecov from the 3.12 matrix entry (the existing `codecov` token in `requirements.txt` is reused via `secrets.CODECOV_TOKEN`)

### Bug fixed during testing

[mailsuite/imap.py:349-354](mailsuite/imap.py#L349-L354) — `IMAPClient.delete_messages(int)` crashed because the log statement tried to iterate over the int before the `[int(messages)]` coercion ran. The type signature claims `int` is supported. Test `test_int_coerced_to_list` caught it; the fix moves the coercion above the log statement.

### Note on PR #19

GitHub merged PR #19 (Microsoft Graph + Gmail backends) into the now-deleted `feat/mailbox-base` branch instead of master, leaving master without the cloud backends. This PR cherry-picks PR #19's commit onto master to land them properly. The history shows two commits on this branch — the cleaner alternative would be to retroactively reopen #19 against master, but rolling it into this release PR keeps the 2.0.0 train moving.

## Test plan

- [x] `pytest` — 205 passed
- [x] `pytest --cov=mailsuite` — 70% line + branch coverage
- [x] `ruff check mailsuite tests` — clean
- [x] `pyright mailsuite` (latest) — clean
- [x] CI workflow YAML validates and references no missing secrets beyond optional `CODECOV_TOKEN`
- [ ] First green CI run on this PR (will validate the 3.9–3.13 matrix and editable-install of `[msgraph,gmail]` extras)

🤖 Generated with [Claude Code](https://claude.com/claude-code)