### PR TITLE
Fix Pylance fetch_message return type and document optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,35 @@ A Python package for retrieving, parsing, and sending emails.
 - Simplified email creation and sending
   - Easily add attachments, plain text, and HTML
   - Uses opportunistic encryption (``STARTTLS``) with SMTP by default
+- DKIM signing and verification
+  - Generate RSA keypairs and the matching DNS TXT record
+  - Sign outbound mail with a sensible default header set (with `From`,
+    `To`, `Cc`, `Subject` oversigned)
+  - Verify one or many `DKIM-Signature` headers on a received message
+- Provider-agnostic mailbox abstraction (`mailsuite.mailbox`)
+  - Single `MailboxConnection` interface for IMAP, Microsoft Graph,
+    Gmail, and on-disk Maildir
+  - Unified `send_message()` on backends that support sending (Microsoft
+    Graph, Gmail) — IMAP and Maildir users send through
+    `mailsuite.smtp.send_email`
+
+## Installation
+
+Base install (IMAP, SMTP, DKIM, Maildir, parsing):
+
+```bash
+pip install mailsuite
+```
+
+The Microsoft Graph and Gmail backends are optional extras — the cloud
+SDKs aren't pulled in unless you ask for them:
+
+```bash
+pip install "mailsuite[msgraph]"   # Microsoft Graph (msgraph-sdk + azure-identity)
+pip install "mailsuite[gmail]"     # Gmail (google-api-python-client + google-auth-oauthlib)
+pip install "mailsuite[all]"       # both
+```
+
+Importing `mailsuite.mailbox` never requires the extras. Referencing
+`MSGraphConnection` or `GmailConnection` without the matching extra
+installed raises an `ImportError` pointing at the right install command.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,38 @@ A Python package for retrieving, parsing, and sending emails.
 - Simplified email creation and sending
   - Easily add attachments, plain text, and HTML
   - Uses opportunistic encryption (``STARTTLS``) with SMTP by default
+- DKIM signing and verification
+  - Generate RSA keypairs and the matching DNS TXT record
+  - Sign outbound mail with a sensible default header set (with `From`,
+    `To`, `Cc`, `Subject` oversigned)
+  - Verify one or many `DKIM-Signature` headers on a received message
+- Provider-agnostic mailbox abstraction (`mailsuite.mailbox`)
+  - Single `MailboxConnection` interface for IMAP, Microsoft Graph,
+    Gmail, and on-disk Maildir
+  - Unified `send_message()` on backends that support sending (Microsoft
+    Graph, Gmail) — IMAP and Maildir users send through
+    `mailsuite.smtp.send_email`
+
+## Installation
+
+Base install (IMAP, SMTP, DKIM, Maildir, parsing):
+
+```bash
+pip install mailsuite
+```
+
+The Microsoft Graph and Gmail backends are optional extras — the cloud
+SDKs aren't pulled in unless you ask for them:
+
+```bash
+pip install "mailsuite[msgraph]"   # Microsoft Graph (msgraph-sdk + azure-identity)
+pip install "mailsuite[gmail]"     # Gmail (google-api-python-client + google-auth-oauthlib)
+pip install "mailsuite[all]"       # both
+```
+
+Importing `mailsuite.mailbox` never requires the extras. Referencing
+`MSGraphConnection` or `GmailConnection` without the matching extra
+installed raises an `ImportError` pointing at the right install command.
 
 ## Email samples and Outlook clients
 

--- a/mailsuite/mailbox/graph.py
+++ b/mailsuite/mailbox/graph.py
@@ -291,9 +291,11 @@ class MSGraphConnection(MailboxConnection):
         )
         if kwargs.get("mark_read"):
             self.mark_message_read(str(message_id))
-        if isinstance(raw, bytes):
-            return raw.decode("utf-8", errors="replace")
-        return raw or ""
+        if raw is None:
+            return ""
+        if isinstance(raw, str):
+            return raw
+        return bytes(raw).decode("utf-8", errors="replace")
 
     def mark_message_read(self, message_id: str) -> None:
         _run(


### PR DESCRIPTION
## Summary

- Fix Pylance `reportReturnType` error on [mailsuite/mailbox/graph.py:296](mailsuite/mailbox/graph.py#L296). Pylance's bundled typeshed widens the SDK's Buffer-typed return to `bytes | bytearray | memoryview | None`, so `isinstance(raw, bytes)` doesn't narrow `bytearray`/`memoryview` away from the fallback `return raw or ""`. Replaced with a None/str/buffer ladder that converts via `bytes(raw).decode(...)` — same pattern we already use in `mailsuite.dkim`.
- Add an **Installation** section to [README.md](README.md) and [docs/index.md](docs/index.md) explaining the `[msgraph]`, `[gmail]`, and `[all]` extras and the lazy-import behavior of `mailsuite.mailbox`.
- Also expand the Features list in both files to mention DKIM signing/verification and the new mailbox abstraction (those weren't called out from the 2.0 release).

## Test plan

- [x] `pytest` — 205 passed (no behavior change; the buffer types decode identically)
- [x] `ruff check mailsuite tests` — clean
- [x] `pyright mailsuite` (latest) — clean
- [x] CI workflow runs on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)