### PR TITLE
MSGraphConnection: graph_url and overrideable token_cache_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - `MailboxConnection` ABC with `create_folder`, `fetch_messages`, `fetch_message`, `delete_message`, `move_message`, `keepalive`, `watch`, and `send_message`
   - `IMAPConnection` (built on `mailsuite.imap.IMAPClient`, IDLE-based watch loop)
   - `MaildirConnection` (built on the stdlib `mailbox.Maildir`)
-  - `MSGraphConnection` (built on `msgraph-sdk`; sends through `/users/{mailbox}/sendMail`). Requires the `mailsuite[msgraph]` extra.
+  - `MSGraphConnection` (built on `msgraph-sdk`; sends through `/users/{mailbox}/sendMail`). Requires the `mailsuite[msgraph]` extra. Constructor accepts `graph_url` (any Microsoft Graph endpoint — sovereign clouds, dev/test endpoints, etc.) and `token_cache_name` (defaults to `"mailsuite"`; pass the previous installation's cache name — e.g. `"parsedmarc"` — for seamless migration so cached `AuthenticationRecord`s carry over without re-prompting users).
   - `GmailConnection` (built on `google-api-python-client`; sends through `users.messages.send`). Requires the `mailsuite[gmail]` extra.
   - Optional cloud backends are loaded lazily via PEP 562 — importing `mailsuite.mailbox` never requires the extras to be installed; referencing the class surfaces a clear `ImportError` if they aren't.
   - `send_message()` raises `NotImplementedError` on the receive-only IMAP and Maildir backends; use `mailsuite.smtp.send_email` for standalone sending.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,20 @@ pip install "mailsuite[all]"       # both
 Importing `mailsuite.mailbox` never requires the extras. Referencing
 `MSGraphConnection` or `GmailConnection` without the matching extra
 installed raises an `ImportError` pointing at the right install command.
+
+## Microsoft Graph notes
+
+`MSGraphConnection` defaults to the worldwide cloud
+(`https://graph.microsoft.com`). To target a sovereign cloud or any
+other Graph endpoint, pass `graph_url`:
+
+```python
+MSGraphConnection(..., graph_url="https://graph.microsoft.us")
+```
+
+The `azure-identity` token cache lives under `name="mailsuite"` by
+default. Applications migrating from a previous installation that used a
+different cache name can pass it through `token_cache_name=` so existing
+cached `AuthenticationRecord`s and tokens continue to work — for
+example, `token_cache_name="parsedmarc"` keeps users authenticated
+across the migration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,23 @@ Importing `mailsuite.mailbox` never requires the extras. Referencing
 `MSGraphConnection` or `GmailConnection` without the matching extra
 installed raises an `ImportError` pointing at the right install command.
 
+## Microsoft Graph notes
+
+`MSGraphConnection` defaults to the worldwide cloud
+(`https://graph.microsoft.com`). To target a sovereign cloud or any
+other Graph endpoint, pass `graph_url`:
+
+```python
+MSGraphConnection(..., graph_url="https://graph.microsoft.us")
+```
+
+The `azure-identity` token cache lives under `name="mailsuite"` by
+default. Applications migrating from a previous installation that used a
+different cache name can pass it through `token_cache_name=` so existing
+cached `AuthenticationRecord`s and tokens continue to work — for
+example, `token_cache_name="parsedmarc"` keeps users authenticated
+across the migration.
+
 ## Email samples and Outlook clients
 
 ### Microsoft Outlook for Windows

--- a/mailsuite/mailbox/graph.py
+++ b/mailsuite/mailbox/graph.py
@@ -21,6 +21,10 @@ try:
         TokenCachePersistenceOptions,
         UsernamePasswordCredential,
     )
+    from kiota_authentication_azure.azure_identity_authentication_provider import (
+        AzureIdentityAuthenticationProvider,
+    )
+    from msgraph.graph_request_adapter import GraphRequestAdapter
     from msgraph.graph_service_client import GraphServiceClient
     from msgraph.generated.models.body_type import BodyType
     from msgraph.generated.models.email_address import EmailAddress
@@ -44,6 +48,7 @@ try:
     from msgraph.generated.users.item.send_mail.send_mail_post_request_body import (
         SendMailPostRequestBody,
     )
+    from msgraph_core import GraphClientFactory
 except ImportError as e:
     raise ImportError(
         "MSGraphConnection requires the 'msgraph' extra: "
@@ -60,10 +65,17 @@ class AuthMethod(Enum):
     Certificate = 4
 
 
-def _get_cache_args(token_path: Path, allow_unencrypted_storage: bool) -> dict:
+DEFAULT_TOKEN_CACHE_NAME = "mailsuite"
+
+
+def _get_cache_args(
+    token_path: Path,
+    allow_unencrypted_storage: bool,
+    cache_name: str = DEFAULT_TOKEN_CACHE_NAME,
+) -> dict:
     cache_args: dict = {
         "cache_persistence_options": TokenCachePersistenceOptions(
-            name="mailsuite", allow_unencrypted_storage=allow_unencrypted_storage
+            name=cache_name, allow_unencrypted_storage=allow_unencrypted_storage
         )
     }
     auth_record = _load_token(token_path)
@@ -89,6 +101,7 @@ def _cache_auth_record(record: AuthenticationRecord, token_path: Path) -> None:
 
 
 def _generate_credential(auth_method: str, token_path: Path, **kwargs):
+    cache_name = kwargs.get("cache_name", DEFAULT_TOKEN_CACHE_NAME)
     if auth_method == AuthMethod.DeviceCode.name:
         return DeviceCodeCredential(
             client_id=kwargs["client_id"],
@@ -97,6 +110,7 @@ def _generate_credential(auth_method: str, token_path: Path, **kwargs):
             **_get_cache_args(
                 token_path,
                 allow_unencrypted_storage=kwargs["allow_unencrypted_storage"],
+                cache_name=cache_name,
             ),
         )
     if auth_method == AuthMethod.UsernamePassword.name:
@@ -109,6 +123,7 @@ def _generate_credential(auth_method: str, token_path: Path, **kwargs):
             **_get_cache_args(
                 token_path,
                 allow_unencrypted_storage=kwargs["allow_unencrypted_storage"],
+                cache_name=cache_name,
             ),
         )
     if auth_method == AuthMethod.ClientSecret.name:
@@ -180,7 +195,34 @@ class MSGraphConnection(MailboxConnection):
         allow_unencrypted_storage: bool,
         certificate_path: Optional[str] = None,
         certificate_password: Optional[Union[str, bytes]] = None,
+        graph_url: Optional[str] = None,
+        token_cache_name: str = DEFAULT_TOKEN_CACHE_NAME,
     ):
+        """
+        Args:
+            auth_method: One of the names in :class:`AuthMethod`
+            mailbox: The mailbox UPN (e.g. ``user@example.com``)
+            client_id: Application (client) ID
+            client_secret: Client secret (required for ClientSecret auth)
+            username: User principal name (required for UsernamePassword auth)
+            password: Password (required for UsernamePassword auth)
+            tenant_id: Azure AD tenant ID
+            token_file: Path to the file used to persist the
+                ``AuthenticationRecord`` between runs
+            allow_unencrypted_storage: Pass through to
+                :class:`azure.identity.TokenCachePersistenceOptions`
+            certificate_path: PEM/PFX path for Certificate auth
+            certificate_password: Optional password for the certificate
+            graph_url: Microsoft Graph endpoint URL. Defaults to the worldwide
+                cloud. Pass a sovereign cloud URL (e.g.
+                ``"https://graph.microsoft.us"``) or any other Graph endpoint
+                to override.
+            token_cache_name: ``msal``/``azure-identity`` token cache name.
+                Defaults to ``"mailsuite"``. Downstream consumers migrating
+                from a previous installation can pass the old cache name
+                (e.g. ``"parsedmarc"``) so existing cached
+                ``AuthenticationRecord``s and tokens continue to work.
+        """
         token_path = Path(token_file)
         credential = _generate_credential(
             auth_method,
@@ -193,6 +235,7 @@ class MSGraphConnection(MailboxConnection):
             tenant_id=tenant_id,
             token_path=token_path,
             allow_unencrypted_storage=allow_unencrypted_storage,
+            cache_name=token_cache_name,
         )
 
         scopes: Optional[List[str]] = None
@@ -204,7 +247,18 @@ class MSGraphConnection(MailboxConnection):
             auth_record = credential.authenticate(scopes=scopes)
             _cache_auth_record(auth_record, token_path)
 
-        self._client = GraphServiceClient(credentials=credential, scopes=scopes)
+        if graph_url is None:
+            self._client = GraphServiceClient(credentials=credential, scopes=scopes)
+        else:
+            httpx_client = GraphClientFactory.create_with_default_middleware()
+            httpx_client.base_url = f"{graph_url.rstrip('/')}/v1.0"
+            auth_provider = AzureIdentityAuthenticationProvider(
+                credentials=credential, scopes=scopes or []
+            )
+            adapter = GraphRequestAdapter(
+                auth_provider=auth_provider, client=httpx_client
+            )
+            self._client = GraphServiceClient(request_adapter=adapter)
         self.mailbox_name = mailbox
 
     # — folder management —

--- a/tests/test_mailbox_graph.py
+++ b/tests/test_mailbox_graph.py
@@ -19,6 +19,7 @@ pytest.importorskip("azure.identity")
 
 from mailsuite.mailbox import MailboxConnection  # noqa: E402
 from mailsuite.mailbox.graph import (  # noqa: E402
+    DEFAULT_TOKEN_CACHE_NAME,
     AuthMethod,
     MSGraphConnection,
     _generate_credential,
@@ -432,3 +433,149 @@ class TestWatch:
 
         conn.watch(cb, check_timeout=0, config_reloading=reload)
         assert calls["n"] == 1
+
+
+class TestGraphUrl:
+    """The graph_url parameter must override the httpx client base URL."""
+
+    def _build(self, graph_url, monkeypatch):
+        # Bypass real cert auth by stubbing _generate_credential to return a
+        # ClientSecretCredential subclass — the constructor branches on that
+        # type to skip the interactive `authenticate()` step.
+        from azure.identity import ClientSecretCredential
+        from mailsuite.mailbox import graph as graph_mod
+
+        class FakeCred(ClientSecretCredential):
+            def __init__(self):
+                pass  # bypass real Azure SDK init
+
+            def get_token(self, *a, **k):
+                return None
+
+        monkeypatch.setattr(
+            graph_mod, "_generate_credential", lambda *a, **k: FakeCred()
+        )
+        return MSGraphConnection(
+            auth_method=AuthMethod.ClientSecret.name,
+            mailbox="user@example.com",
+            client_id="c",
+            client_secret="s",
+            username=None,
+            password=None,
+            tenant_id="t",
+            token_file="/tmp/unused-token",
+            allow_unencrypted_storage=False,
+            graph_url=graph_url,
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://graph.microsoft.us",
+            "https://dod-graph.microsoft.us",
+            "https://microsoftgraph.chinacloudapi.cn",
+            "https://graph.microsoft.de",
+            "https://graph.example.test",
+            "https://graph.microsoft.us/",  # trailing slash stripped
+        ],
+    )
+    def test_overrides_base_url(self, url, monkeypatch):
+        conn = self._build(url, monkeypatch)
+        base = str(conn._client.request_adapter._http_client.base_url)
+        assert url.rstrip("/") in base
+        assert base.endswith("/v1.0") or base.endswith("/v1.0/")
+
+
+class TestCacheName:
+    def test_default_constant(self):
+        assert DEFAULT_TOKEN_CACHE_NAME == "mailsuite"
+
+    def test_default_cache_name_passed_through(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_token_cache_options(name, allow_unencrypted_storage):
+            captured["name"] = name
+            return MagicMock()
+
+        from mailsuite.mailbox import graph as graph_mod
+
+        monkeypatch.setattr(
+            graph_mod, "TokenCachePersistenceOptions", fake_token_cache_options
+        )
+
+        # Construct only the credential; bypass real DeviceCodeCredential
+        class FakeDevCred:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        monkeypatch.setattr(graph_mod, "DeviceCodeCredential", FakeDevCred)
+
+        _generate_credential(
+            AuthMethod.DeviceCode.name,
+            tmp_path / "tok",
+            client_id="c",
+            tenant_id="t",
+            allow_unencrypted_storage=True,
+        )
+        assert captured["name"] == "mailsuite"
+
+    def test_overridden_cache_name(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_token_cache_options(name, allow_unencrypted_storage):
+            captured["name"] = name
+            return MagicMock()
+
+        from mailsuite.mailbox import graph as graph_mod
+
+        monkeypatch.setattr(
+            graph_mod, "TokenCachePersistenceOptions", fake_token_cache_options
+        )
+
+        class FakeDevCred:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        monkeypatch.setattr(graph_mod, "DeviceCodeCredential", FakeDevCred)
+
+        _generate_credential(
+            AuthMethod.DeviceCode.name,
+            tmp_path / "tok",
+            client_id="c",
+            tenant_id="t",
+            allow_unencrypted_storage=False,
+            cache_name="parsedmarc",
+        )
+        assert captured["name"] == "parsedmarc"
+
+    def test_cache_name_for_username_password(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_token_cache_options(name, allow_unencrypted_storage):
+            captured["name"] = name
+            return MagicMock()
+
+        from mailsuite.mailbox import graph as graph_mod
+
+        monkeypatch.setattr(
+            graph_mod, "TokenCachePersistenceOptions", fake_token_cache_options
+        )
+
+        class FakeUPCred:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        monkeypatch.setattr(graph_mod, "UsernamePasswordCredential", FakeUPCred)
+
+        _generate_credential(
+            AuthMethod.UsernamePassword.name,
+            tmp_path / "tok",
+            client_id="c",
+            client_secret="s",
+            username="u",
+            password="p",
+            tenant_id="t",
+            allow_unencrypted_storage=True,
+            cache_name="parsedmarc",
+        )
+        assert captured["name"] == "parsedmarc"


### PR DESCRIPTION
## Summary

Closes the parsedmarc parity gap that the `msgraph-core 0.2.x` → `msgraph-sdk` migration introduced. parsedmarc historically forwarded `graph_url` to `GraphClient(cloud=...)` and used a `parsedmarc`-named token cache. We restore both.

| New param | Default | Purpose |
|---|---|---|
| `graph_url` | `None` (worldwide cloud) | Microsoft Graph endpoint URL — sovereign clouds, dev/test endpoints, etc. |
| `token_cache_name` | `\"mailsuite\"` | Overrides the `azure-identity` token cache name. Pass the previous installation's name (e.g. `\"parsedmarc\"`) so cached `AuthenticationRecord`s and tokens carry over and users aren't re-prompted to authenticate. |

When `graph_url` is given, the constructor builds an `httpx.AsyncClient` from `GraphClientFactory.create_with_default_middleware()`, overrides `client.base_url` to `f\"{graph_url}/v1.0\"`, and wraps it in a `GraphRequestAdapter`. Otherwise the stock `GraphServiceClient(credentials, scopes)` is used unchanged.

### Note for parsedmarc consumers

When parsedmarc adopts mailsuite for its mailbox layer, pass `token_cache_name=\"parsedmarc\"` and forward the existing `graph_url` config knob. The migration will be invisible to end users.

## Test plan

- [x] `pytest` — 215 passed (10 new tests covering `graph_url` overrides for sovereign clouds + arbitrary URLs and `token_cache_name` for both DeviceCode and UsernamePassword auth)
- [x] `ruff check mailsuite tests` — clean
- [x] `pyright mailsuite` (latest) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)