### PR TITLE
Backfill mailbox tests from parsedmarc

### DIFF
--- a/tests/test_mailbox_gmail.py
+++ b/tests/test_mailbox_gmail.py
@@ -295,3 +295,41 @@ class TestWatch:
 
         conn.watch(cb, check_timeout=0, config_reloading=reload)
         assert calls["n"] == 1
+
+
+class TestTokenFileMkdir:
+    """_get_creds must create the parent directory of the token file when
+    persisting newly-issued credentials. Callers point token_file at paths
+    inside fresh config directories.
+    """
+
+    def test_installed_app_creates_parent_dirs(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from mailsuite.mailbox import gmail as gmail_mod
+
+        token_path = tmp_path / "deep" / "nested" / "token.json"
+        creds_file = tmp_path / "client_secrets.json"
+        creds_file.write_text("{}")
+
+        # Stub the OAuth flow — return a fake creds whose to_json() yields a
+        # known string we can assert on.
+        fake_creds = MagicMock()
+        fake_creds.valid = True
+        fake_creds.to_json.return_value = '{"access_token": "stub"}'
+        fake_flow = MagicMock()
+        fake_flow.run_local_server.return_value = fake_creds
+        monkeypatch.setattr(
+            gmail_mod.InstalledAppFlow,
+            "from_client_secrets_file",
+            classmethod(lambda cls, f, s: fake_flow),
+        )
+
+        assert not token_path.parent.exists()
+        result = gmail_mod._get_creds(
+            str(token_path), str(creds_file), ["scope"], oauth2_port=0
+        )
+
+        assert result is fake_creds
+        assert token_path.exists()
+        assert token_path.read_text() == '{"access_token": "stub"}'

--- a/tests/test_mailbox_graph.py
+++ b/tests/test_mailbox_graph.py
@@ -579,3 +579,98 @@ class TestCacheName:
             cache_name="parsedmarc",
         )
         assert captured["name"] == "parsedmarc"
+
+
+class TestSharedMailboxScopes:
+    """When mailbox != username, MSGraphConnection must request the
+    Mail.ReadWrite.Shared scope (instead of Mail.ReadWrite). This is the
+    only signal that distinguishes a shared mailbox from the signed-in
+    user's own — silent regression here breaks shared-mailbox callers.
+    """
+
+    def _construct(self, monkeypatch, *, mailbox: str, username: str):
+        from unittest.mock import MagicMock
+
+        from mailsuite.mailbox import graph as graph_mod
+
+        # Track scopes passed to credential.authenticate()
+        captured = {}
+
+        class FakeCredential:
+            def authenticate(self, scopes):
+                captured["scopes"] = list(scopes)
+                return MagicMock()
+
+        monkeypatch.setattr(
+            graph_mod, "_generate_credential", lambda *a, **k: FakeCredential()
+        )
+        monkeypatch.setattr(graph_mod, "_cache_auth_record", lambda *a, **k: None)
+        # Don't actually construct an SDK client (no network/auth)
+        monkeypatch.setattr(
+            graph_mod, "GraphServiceClient", lambda **kwargs: MagicMock()
+        )
+
+        MSGraphConnection(
+            auth_method=AuthMethod.DeviceCode.name,
+            mailbox=mailbox,
+            client_id="cid",
+            client_secret="secret",
+            username=username,
+            password="pass",
+            tenant_id="tenant",
+            token_file="/tmp/unused-token",
+            allow_unencrypted_storage=True,
+        )
+        return captured
+
+    def test_shared_mailbox_uses_shared_scope(self, monkeypatch):
+        captured = self._construct(
+            monkeypatch,
+            mailbox="shared@example.com",
+            username="owner@example.com",
+        )
+        assert captured["scopes"] == ["Mail.ReadWrite.Shared"]
+
+    def test_own_mailbox_uses_personal_scope(self, monkeypatch):
+        captured = self._construct(
+            monkeypatch,
+            mailbox="user@example.com",
+            username="user@example.com",
+        )
+        assert captured["scopes"] == ["Mail.ReadWrite"]
+
+
+class TestCacheAuthRecord:
+    """_cache_auth_record must create the parent directory if it doesn't
+    exist. parsedmarc relied on this when token_file pointed at a path
+    inside a fresh config directory.
+    """
+
+    def test_creates_nested_parent_dirs(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from mailsuite.mailbox.graph import _cache_auth_record
+
+        token_path = tmp_path / "subdir" / "nested" / ".token"
+        assert not token_path.parent.exists()
+
+        record = MagicMock()
+        record.serialize.return_value = "serialized-token"
+        _cache_auth_record(record, token_path)
+
+        assert token_path.exists()
+        assert token_path.read_text() == "serialized-token"
+
+    def test_existing_parent_no_op(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from mailsuite.mailbox.graph import _cache_auth_record
+
+        token_path = tmp_path / ".token"
+        record = MagicMock()
+        record.serialize.return_value = "data"
+        _cache_auth_record(record, token_path)
+        # Re-write — should not error even though parent already exists
+        record.serialize.return_value = "data2"
+        _cache_auth_record(record, token_path)
+        assert token_path.read_text() == "data2"

--- a/tests/test_mailbox_maildir.py
+++ b/tests/test_mailbox_maildir.py
@@ -170,3 +170,78 @@ class TestMaildirConnection:
 
         # Should log warning and exit cleanly without re-raising
         conn.watch(cb, check_timeout=0, config_reloading=reload)
+
+
+class TestUidMismatch:
+    """Maildir on Linux/Docker often runs with a non-root user that doesn't
+    own the maildir directory. We must warn — not crash — so the operator
+    can fix permissions instead of debugging an unhandled OSError on import.
+    """
+
+    def test_non_root_mismatch_warns(self, maildir_path, monkeypatch, caplog):
+        import logging
+        import os
+
+        from mailsuite.mailbox import maildir as md_mod
+
+        real_stat = os.stat(maildir_path)
+        # os.stat returns a real stat_result; the .st_uid attribute is the
+        # only field the implementation reads. Ensure mismatch by claiming
+        # owner uid is one above whatever the runtime uid will be.
+        runtime_uid = 1000
+        owner_uid = runtime_uid + 1
+
+        class FakeStat:
+            st_uid = owner_uid
+
+            def __getattr__(self, name):
+                return getattr(real_stat, name)
+
+        monkeypatch.setattr(md_mod.os, "stat", lambda p: FakeStat())
+        monkeypatch.setattr(md_mod.os, "getuid", lambda: runtime_uid)
+
+        with caplog.at_level(logging.WARNING, logger="mailsuite.mailbox.maildir"):
+            # Should not raise — just warn
+            MaildirConnection(maildir_path, maildir_create=False)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("differs from maildir" in r.getMessage() for r in warnings)
+
+    def test_root_with_mismatch_attempts_setuid(self, maildir_path, monkeypatch):
+        import os
+
+        from mailsuite.mailbox import maildir as md_mod
+
+        real_stat = os.stat(maildir_path)
+        owner_uid = 1234
+
+        class FakeStat:
+            st_uid = owner_uid
+
+            def __getattr__(self, name):
+                return getattr(real_stat, name)
+
+        setuid_calls = []
+        monkeypatch.setattr(md_mod.os, "stat", lambda p: FakeStat())
+        monkeypatch.setattr(md_mod.os, "getuid", lambda: 0)
+        monkeypatch.setattr(md_mod.os, "setuid", lambda uid: setuid_calls.append(uid))
+
+        MaildirConnection(maildir_path, maildir_create=False)
+        assert setuid_calls == [owner_uid]
+
+    def test_no_mismatch_no_warning(self, maildir_path, monkeypatch, caplog):
+        import logging
+        import os
+
+        from mailsuite.mailbox import maildir as md_mod
+
+        real_stat = os.stat(maildir_path)
+        # owner uid matches the (faked) runtime uid → no warning, no setuid
+        monkeypatch.setattr(md_mod.os, "getuid", lambda: real_stat.st_uid)
+
+        with caplog.at_level(logging.WARNING, logger="mailsuite.mailbox.maildir"):
+            MaildirConnection(maildir_path, maildir_create=False)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("differs from maildir" in r.getMessage() for r in warnings)
+        assert not any("Switching uid" in r.getMessage() for r in warnings)


### PR DESCRIPTION
## Summary

Ports the four mailbox-related behaviors that parsedmarc's `tests.py` covers but our suite missed:

- **`TestSharedMailboxScopes`** ([tests/test_mailbox_graph.py](tests/test_mailbox_graph.py)) — verifies `MSGraphConnection` upgrades to `Mail.ReadWrite.Shared` when `mailbox != username`. This is the only signal distinguishing a shared mailbox from the signed-in user's own; a silent regression here breaks shared-mailbox callers (a common parsedmarc deployment pattern). Two cases: shared-mailbox upgrade and own-mailbox stays at `Mail.ReadWrite`.
- **`TestCacheAuthRecord`** ([tests/test_mailbox_graph.py](tests/test_mailbox_graph.py)) — `_cache_auth_record` creates nested parent directories on first run, and re-writing into an existing parent doesn't error.
- **`TestTokenFileMkdir`** ([tests/test_mailbox_gmail.py](tests/test_mailbox_gmail.py)) — `_get_creds` (installed-app flow) creates parent dirs when persisting credentials from a fresh OAuth flow. Stubs `InstalledAppFlow.from_client_secrets_file` so the test runs without browser/network.
- **`TestUidMismatch`** ([tests/test_mailbox_maildir.py](tests/test_mailbox_maildir.py)) — `MaildirConnection` warns (doesn't crash) when the runtime uid doesn't own the maildir directory, attempts `setuid` when running as root, and stays quiet when uids match. Important for Docker/postfix deployments where these mismatches are routine.

The remaining mail-related tests in parsedmarc's `tests.py` are either parsedmarc-CLI-specific (env var parsing, config aliases like `[msgraph] url`, `[maildir] maildir_create`) or already covered by our existing mocks.

## Test plan

- [x] `pytest` — 223 passed (8 new)
- [x] `ruff check mailsuite tests` — clean
- [x] `pyright mailsuite` (latest) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)