### PR TITLE
Fix select_folder for shared / other-users IMAP namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Optional cloud backends are loaded lazily via PEP 562 — importing `mailsuite.mailbox` never requires the extras to be installed; referencing the class surfaces a clear `ImportError` if they aren't.
   - `send_message()` raises `NotImplementedError` on the receive-only IMAP and Maildir backends; use `mailsuite.smtp.send_email` for standalone sending.
 - Add a comprehensive `pytest` test suite covering all modules, plus a GitHub Actions CI workflow that runs `ruff`, `pyright`, and `pytest` (with coverage) across supported Python versions
+- Fix `IMAPClient.select_folder` (and other folder operations) on shared / other-users namespaces. `_normalise_folder` previously prepended the personal namespace prefix to every path, so e.g. `user/colleague/Inbox` became `INBOX/user/colleague/Inbox`. Paths already inside an RFC 2342 non-personal namespace are now passed through untouched (#13).
 
 ## 1.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+- Fix `IMAPClient.select_folder` (and other folder operations) on shared / other-users namespaces. `_normalise_folder` previously prepended the personal namespace prefix to every path, so e.g. `user/colleague/Inbox` became `INBOX/user/colleague/Inbox`. Paths already inside an RFC 2342 non-personal namespace are now passed through untouched (#13).
+
 ## 2.0.0
 
 - Add a new `mailsuite.dkim` module for DKIM key generation, public key extraction, TXT record generation, email signing, and signature verification
@@ -13,7 +17,6 @@
   - Optional cloud backends are loaded lazily via PEP 562 — importing `mailsuite.mailbox` never requires the extras to be installed; referencing the class surfaces a clear `ImportError` if they aren't.
   - `send_message()` raises `NotImplementedError` on the receive-only IMAP and Maildir backends; use `mailsuite.smtp.send_email` for standalone sending.
 - Add a comprehensive `pytest` test suite covering all modules, plus a GitHub Actions CI workflow that runs `ruff`, `pyright`, and `pytest` (with coverage) across supported Python versions
-- Fix `IMAPClient.select_folder` (and other folder operations) on shared / other-users namespaces. `_normalise_folder` previously prepended the personal namespace prefix to every path, so e.g. `user/colleague/Inbox` became `INBOX/user/colleague/Inbox`. Paths already inside an RFC 2342 non-personal namespace are now passed through untouched (#13).
 
 ## 1.11.2
 

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -58,6 +58,17 @@ class IMAPClient(imapclient.IMAPClient):
             return str(result)
 
         folder_name = folder_name.rstrip("/")
+
+        # If the path is already inside a non-personal namespace (other-users
+        # or shared per RFC 2342), pass it through without applying the
+        # personal-namespace prefix. Otherwise paths like "user/colleague/Inbox"
+        # would get rewritten to "INBOX/user/colleague/Inbox".
+        if any(folder_name.startswith(p) for p in self._other_namespace_prefixes):
+            result = imapclient.IMAPClient._normalise_folder(self, folder_name)
+            if isinstance(result, bytes):
+                return result.decode("utf-8", "replace")
+            return str(result)
+
         folder_name = folder_name.replace(self._path_prefix, "")
         if not self._hierarchy_separator == "/":
             folder_name = folder_name.replace(self._hierarchy_separator, "")
@@ -180,6 +191,7 @@ class IMAPClient(imapclient.IMAPClient):
         self.idle_callback = idle_callback
         self.idle_timeout = idle_timeout
         self._path_prefix = ""
+        self._other_namespace_prefixes: List[str] = []
         self._hierarchy_separator = ""
         if not ssl:
             logger.info("Connecting to IMAP over plain text")
@@ -217,6 +229,16 @@ class IMAPClient(imapclient.IMAPClient):
                         self._path_prefix = personal_namespace[0][0]
                         if type(self._path_prefix) is bytes:
                             self._path_prefix = self._path_prefix.decode("utf-8")
+                # Track non-personal namespace prefixes (other-users, shared)
+                # so _normalise_folder can recognise paths that already live
+                # in a different namespace and leave them alone.
+                for ns in (self._namespace.other, self._namespace.shared):
+                    for entry in ns or ():
+                        prefix = entry[0]
+                        if isinstance(prefix, bytes):
+                            prefix = prefix.decode("utf-8")
+                        if prefix:
+                            self._other_namespace_prefixes.append(prefix)
             else:
                 self._namespace = None
             self.select_folder(initial_folder)

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -23,6 +23,7 @@ def _bare_client(
     *,
     hierarchy_separator: str = "/",
     path_prefix: str = "",
+    other_namespace_prefixes: list[str] | None = None,
     move_supported: bool = True,
     max_retries: int = 4,
 ) -> IMAPClient:
@@ -30,6 +31,7 @@ def _bare_client(
     inst = IMAPClient.__new__(IMAPClient)
     inst._hierarchy_separator = hierarchy_separator
     inst._path_prefix = path_prefix
+    inst._other_namespace_prefixes = other_namespace_prefixes or []
     inst._move_supported = move_supported
     inst.max_retries = max_retries
     inst._init_args = {
@@ -107,6 +109,37 @@ class TestNormaliseFolder:
 
     def test_path_prefix_added(self, monkeypatch):
         client = _bare_client(hierarchy_separator="/", path_prefix="INBOX/")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        assert client._normalise_folder("Reports") == "INBOX/Reports"
+
+    def test_other_users_namespace_passthrough(self, monkeypatch):
+        # Reproduces issue #13: shared folders accessed via the "other users"
+        # namespace must not get the personal prefix prepended.
+        client = _bare_client(
+            hierarchy_separator="/",
+            path_prefix="INBOX/",
+            other_namespace_prefixes=["user/"],
+        )
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        assert (
+            client._normalise_folder("user/colleague/Inbox")
+            == "user/colleague/Inbox"
+        )
+
+    def test_personal_prefix_still_added_for_unprefixed_paths(self, monkeypatch):
+        client = _bare_client(
+            hierarchy_separator="/",
+            path_prefix="INBOX/",
+            other_namespace_prefixes=["user/"],
+        )
         monkeypatch.setattr(
             imapclient.IMAPClient,
             "_normalise_folder",


### PR DESCRIPTION
## Summary
- `IMAPClient._normalise_folder` previously prepended the personal namespace prefix to every non-special path, even when the caller passed a path that already lived in an RFC 2342 *other-users* or *shared* namespace. On the server in #13 (personal `INBOX/`, other-users `user/`, separator `/`), `select_folder("user/colleague/Inbox")` got rewritten to `INBOX/user/colleague/Inbox` and failed.
- Capture the non-personal namespace prefixes during connect (alongside the existing personal-namespace handling) and pass folder paths that already start with one of them through to the base normaliser unchanged. Personal-namespace paths still go through the existing rewrite, so the common case is unaffected.
- Closes #13.

## Test plan
- [x] `pytest tests/test_imap.py` — added regression tests covering the issue-#13 scenario and confirming the existing personal-prefix path still applies.
- [x] `pytest` (full suite, 225 tests) passes.
- [x] `ruff check mailsuite tests` passes.
- [x] `PYRIGHT_PYTHON_FORCE_VERSION=latest pyright mailsuite` reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)