### PR TITLE
Add OAuth2 (XOAUTH2 / OAUTHBEARER) login support to IMAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 2.0.1
 
+- Add OAuth2 (XOAUTH2 / OAUTHBEARER) login support to `mailsuite.imap.IMAPClient` and `mailsuite.mailbox.IMAPConnection`. Pass `oauth2_token=` for a static access token, or `oauth2_token_provider=` (a zero-arg callable) to have a fresh token fetched on every connect/reconnect — recommended for long-running watch / IDLE loops where tokens expire mid-session. Yahoo's vendor string is supported via `oauth2_vendor=`. Workspace and Microsoft 365 users should still prefer the higher-level `GmailConnection` / `MSGraphConnection` backends, which handle token refresh end-to-end (#6).
 - Fix `IMAPClient.select_folder` (and other folder operations) on shared / other-users namespaces. `_normalise_folder` previously prepended the personal namespace prefix to every path, so e.g. `user/colleague/Inbox` became `INBOX/user/colleague/Inbox`. Paths already inside an RFC 2342 non-personal namespace are now passed through untouched (#13).
+- Fix the `IMAPClient` default port (was `933`, now the standard `993`).
 
 ## 2.0.0
 

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union, List, Dict, Optional, cast
+from typing import Callable, Union, List, Dict, Optional, cast
 import time
 import socket
 from ssl import (
@@ -137,9 +137,9 @@ class IMAPClient(imapclient.IMAPClient):
     def __init__(
         self,
         host: str,
-        username: str,
-        password: str,
-        port: int = 933,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        port: int = 993,
         ssl: bool = True,
         ssl_context: Optional[SSLContext] = None,
         verify: bool = True,
@@ -148,14 +148,18 @@ class IMAPClient(imapclient.IMAPClient):
         initial_folder: str = "INBOX",
         idle_callback=None,
         idle_timeout: int = 30,
+        oauth2_token: Optional[str] = None,
+        oauth2_token_provider: Optional[Callable[[], str]] = None,
+        oauth2_mechanism: str = "XOAUTH2",
+        oauth2_vendor: Optional[str] = None,
     ):
         """
         Connects to an IMAP server
 
         Args:
             host: The server hostname or IP address
-            username: The username
-            password: The password
+            username: The username (or OAuth2 identity / email address)
+            password: The password (omit when using OAuth2)
             port: The port
             ssl: Use SSL or TLS
             ssl_context: For more advanced TLS options
@@ -166,6 +170,25 @@ class IMAPClient(imapclient.IMAPClient):
             idle_callback: The function to call when new messages are detected
             idle_timeout: Number of seconds to wait for an IDLE
                                   response
+            oauth2_token: A static OAuth2 access token. For long-running
+                connections (IDLE, reconnects after timeouts) prefer
+                ``oauth2_token_provider`` so a fresh token is fetched on
+                reconnect.
+            oauth2_token_provider: A zero-arg callable returning a current
+                OAuth2 access token. Invoked on every (re)connect, so the
+                callable is responsible for refreshing the token when
+                needed.
+            oauth2_mechanism: ``"XOAUTH2"`` (default — Gmail/Yahoo/M365) or
+                ``"OAUTHBEARER"`` (Gmail's standards-track replacement).
+            oauth2_vendor: Optional vendor string required by Yahoo's
+                XOAUTH2 implementation.
+
+        For Google Workspace and Microsoft 365 the higher-level
+        :class:`mailsuite.mailbox.GmailConnection` and
+        :class:`mailsuite.mailbox.MSGraphConnection` backends are usually
+        a better fit — they speak the providers' native APIs and handle
+        token refresh end-to-end. Generic IMAP OAuth2 is intended for
+        other providers (Yahoo, self-hosted, etc.).
         """
 
         if ssl_context is None:
@@ -173,6 +196,18 @@ class IMAPClient(imapclient.IMAPClient):
         if verify is False:
             ssl_context.check_hostname = False
             ssl_context.verify_mode = CERT_NONE
+        using_oauth = (
+            oauth2_token is not None or oauth2_token_provider is not None
+        )
+        if using_oauth and not username:
+            raise ValueError(
+                "username is required when authenticating with OAuth2"
+            )
+        if not using_oauth and (username is None or password is None):
+            raise ValueError(
+                "either password or an OAuth2 token / token_provider must be "
+                "provided"
+            )
         self._init_args = dict(
             host=host,
             username=username,
@@ -186,6 +221,10 @@ class IMAPClient(imapclient.IMAPClient):
             initial_folder=initial_folder,
             idle_callback=idle_callback,
             idle_timeout=idle_timeout,
+            oauth2_token=oauth2_token,
+            oauth2_token_provider=oauth2_token_provider,
+            oauth2_mechanism=oauth2_mechanism,
+            oauth2_vendor=oauth2_vendor,
         )
         self.max_retries = max_retries
         self.idle_callback = idle_callback
@@ -208,7 +247,23 @@ class IMAPClient(imapclient.IMAPClient):
             if not ssl and b"STARTTLS" in self.capabilities():
                 logger.info("IMAP server supports STARTTLS ... activating now")
                 self.starttls(ssl_context=ssl_context)
-            self.login(username, password)
+            if using_oauth:
+                token = (
+                    oauth2_token_provider()
+                    if oauth2_token_provider is not None
+                    else oauth2_token
+                )
+                if oauth2_mechanism.upper() == "OAUTHBEARER":
+                    self.oauthbearer_login(username, token)
+                else:
+                    self.oauth2_login(
+                        cast(str, username),
+                        cast(str, token),
+                        mech=oauth2_mechanism,
+                        vendor=oauth2_vendor,
+                    )
+            else:
+                self.login(cast(str, username), cast(str, password))
             self.server_capabilities = self.capabilities()
             self._move_supported = b"MOVE" in self.server_capabilities
             self._idle_supported = b"IDLE" in self.server_capabilities
@@ -266,13 +321,17 @@ class IMAPClient(imapclient.IMAPClient):
             self._init_args["password"],  # pyright: ignore[reportArgumentType]
             port=self._init_args["port"],  # pyright: ignore[reportArgumentType]
             ssl=self._init_args["ssl"],  # pyright: ignore[reportArgumentType]
-            ssl_context=self._init_args["ssl_context"],
+            ssl_context=self._init_args["ssl_context"],  # pyright: ignore[reportArgumentType]
             verify=self._init_args["verify"],  # pyright: ignore[reportArgumentType]
             timeout=self._init_args["timeout"],  # pyright: ignore[reportArgumentType]
             max_retries=self._init_args["max_retries"],  # pyright: ignore[reportArgumentType]
             initial_folder=self._init_args["initial_folder"],  # pyright: ignore[reportArgumentType]
             idle_callback=self._init_args["idle_callback"],
             idle_timeout=self._init_args["idle_timeout"],  # pyright: ignore[reportArgumentType]
+            oauth2_token=self._init_args["oauth2_token"],  # pyright: ignore[reportArgumentType]
+            oauth2_token_provider=self._init_args["oauth2_token_provider"],  # pyright: ignore[reportArgumentType]
+            oauth2_mechanism=self._init_args["oauth2_mechanism"],  # pyright: ignore[reportArgumentType]
+            oauth2_vendor=self._init_args["oauth2_vendor"],  # pyright: ignore[reportArgumentType]
         )
 
     def fetch_message(

--- a/mailsuite/mailbox/imap.py
+++ b/mailsuite/mailbox/imap.py
@@ -32,16 +32,42 @@ class IMAPConnection(MailboxConnection):
         self,
         host: str,
         user: str,
-        password: str,
+        password: Optional[str] = None,
         port: int = 993,
         ssl: bool = True,
         verify: bool = True,
         timeout: int = 30,
         max_retries: int = 4,
+        oauth2_token: Optional[str] = None,
+        oauth2_token_provider: Optional[Callable[[], str]] = None,
+        oauth2_mechanism: str = "XOAUTH2",
+        oauth2_vendor: Optional[str] = None,
     ):
+        """
+        Args:
+            host: IMAP server hostname
+            user: Username (or OAuth2 identity / email address)
+            password: Password (omit when using OAuth2)
+            port: Server port
+            ssl: Use SSL/TLS
+            verify: Verify the server's TLS certificate
+            timeout: Per-operation timeout in seconds
+            max_retries: Retries after a timeout
+            oauth2_token: Static OAuth2 access token
+            oauth2_token_provider: Zero-arg callable returning a current
+                token. Re-invoked on reconnect, so the callable is
+                responsible for refreshing the token. Prefer this over
+                ``oauth2_token`` for long-running watch loops.
+            oauth2_mechanism: ``"XOAUTH2"`` (default) or ``"OAUTHBEARER"``
+            oauth2_vendor: Optional vendor string for Yahoo's XOAUTH2
+        """
         self._username = user
         self._password = password
         self._verify = verify
+        self._oauth2_token = oauth2_token
+        self._oauth2_token_provider = oauth2_token_provider
+        self._oauth2_mechanism = oauth2_mechanism
+        self._oauth2_vendor = oauth2_vendor
         self._client = IMAPClient(
             host,
             user,
@@ -51,6 +77,10 @@ class IMAPConnection(MailboxConnection):
             verify=verify,
             timeout=timeout,
             max_retries=max_retries,
+            oauth2_token=oauth2_token,
+            oauth2_token_provider=oauth2_token_provider,
+            oauth2_mechanism=oauth2_mechanism,
+            oauth2_vendor=oauth2_vendor,
         )
 
     def create_folder(self, folder_name: str) -> None:
@@ -121,6 +151,10 @@ class IMAPConnection(MailboxConnection):
                     verify=self._verify,
                     idle_callback=idle_callback_wrapper,
                     idle_timeout=check_timeout,
+                    oauth2_token=self._oauth2_token,
+                    oauth2_token_provider=self._oauth2_token_provider,
+                    oauth2_mechanism=self._oauth2_mechanism,
+                    oauth2_vendor=self._oauth2_vendor,
                 )
             except (timeout, IMAPClientError):
                 logger.warning("IMAP connection timeout. Reconnecting...")

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -47,8 +47,30 @@ def _bare_client(
         "initial_folder": "INBOX",
         "idle_callback": None,
         "idle_timeout": 30,
+        "oauth2_token": None,
+        "oauth2_token_provider": None,
+        "oauth2_mechanism": "XOAUTH2",
+        "oauth2_vendor": None,
     }
     return inst
+
+
+def _stub_network(monkeypatch):
+    """Stub everything in the base IMAPClient that does network I/O."""
+    monkeypatch.setattr(
+        imapclient.IMAPClient, "__init__", lambda self, **kw: None
+    )
+    monkeypatch.setattr(
+        imapclient.IMAPClient, "capabilities", lambda self: (b"IMAP4rev1",)
+    )
+    monkeypatch.setattr(
+        imapclient.IMAPClient,
+        "list_folders",
+        lambda self: [((), b"/", b"INBOX")],
+    )
+    monkeypatch.setattr(
+        imapclient.IMAPClient, "select_folder", lambda self, name: None
+    )
 
 
 class TestChunks:
@@ -344,3 +366,118 @@ class TestMoveMessages:
 class TestExceptions:
     def test_max_retries_is_runtime_error(self):
         assert issubclass(MaxRetriesExceeded, RuntimeError)
+
+
+class TestOAuth2Login:
+    def test_password_auth_calls_login(self, monkeypatch):
+        _stub_network(monkeypatch)
+        called = {}
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "login",
+            lambda self, u, p: called.update(user=u, pw=p),
+        )
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "oauth2_login",
+            lambda *a, **k: pytest.fail("oauth2_login should not be called"),
+        )
+        IMAPClient("host", "u@example.com", "secret")
+        assert called == {"user": "u@example.com", "pw": "secret"}
+
+    def test_static_oauth2_token_uses_xoauth2(self, monkeypatch):
+        _stub_network(monkeypatch)
+        called = {}
+
+        def fake_oauth(self, user, token, mech="XOAUTH2", vendor=None):
+            called.update(user=user, token=token, mech=mech, vendor=vendor)
+
+        monkeypatch.setattr(imapclient.IMAPClient, "oauth2_login", fake_oauth)
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "login",
+            lambda *a, **k: pytest.fail("login should not be called"),
+        )
+        IMAPClient("host", "u@example.com", oauth2_token="tok-123")
+        assert called == {
+            "user": "u@example.com",
+            "token": "tok-123",
+            "mech": "XOAUTH2",
+            "vendor": None,
+        }
+
+    def test_token_provider_invoked_each_connect(self, monkeypatch):
+        _stub_network(monkeypatch)
+        tokens = iter(["tok-1", "tok-2", "tok-3"])
+        provider_calls = {"n": 0}
+
+        def provider():
+            provider_calls["n"] += 1
+            return next(tokens)
+
+        seen_tokens: list[str] = []
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "oauth2_login",
+            lambda self, user, token, mech="XOAUTH2", vendor=None: (
+                seen_tokens.append(token)
+            ),
+        )
+        client = IMAPClient(
+            "host", "u@example.com", oauth2_token_provider=provider
+        )
+        # Reconnect: the provider must be called again so the new
+        # connection uses a fresh access token.
+        monkeypatch.setattr(client, "shutdown", lambda: None)
+        client.reset_connection()
+        assert provider_calls["n"] == 2
+        assert seen_tokens == ["tok-1", "tok-2"]
+
+    def test_oauthbearer_mechanism(self, monkeypatch):
+        _stub_network(monkeypatch)
+        called = {}
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "oauthbearer_login",
+            lambda self, identity, token: called.update(
+                identity=identity, token=token
+            ),
+        )
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "oauth2_login",
+            lambda *a, **k: pytest.fail("oauth2_login should not be called"),
+        )
+        IMAPClient(
+            "host",
+            "u@example.com",
+            oauth2_token="tok",
+            oauth2_mechanism="OAUTHBEARER",
+        )
+        assert called == {"identity": "u@example.com", "token": "tok"}
+
+    def test_yahoo_vendor_passed_through(self, monkeypatch):
+        _stub_network(monkeypatch)
+        seen = {}
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "oauth2_login",
+            lambda self, user, token, mech="XOAUTH2", vendor=None: seen.update(
+                vendor=vendor
+            ),
+        )
+        IMAPClient(
+            "host",
+            "u@yahoo.com",
+            oauth2_token="tok",
+            oauth2_vendor="yahoo",
+        )
+        assert seen == {"vendor": "yahoo"}
+
+    def test_missing_credentials_raises(self):
+        with pytest.raises(ValueError, match="password or an OAuth2"):
+            IMAPClient("host", "u@example.com")
+
+    def test_oauth_without_username_raises(self):
+        with pytest.raises(ValueError, match="username is required"):
+            IMAPClient("host", oauth2_token="tok")

--- a/tests/test_mailbox_imap.py
+++ b/tests/test_mailbox_imap.py
@@ -16,6 +16,10 @@ def _bare_connection() -> IMAPConnection:
     inst._username = "user"
     inst._password = "pw"
     inst._verify = True
+    inst._oauth2_token = None
+    inst._oauth2_token_provider = None
+    inst._oauth2_mechanism = "XOAUTH2"
+    inst._oauth2_vendor = None
     inst._client = MagicMock()
     return inst
 
@@ -83,3 +87,27 @@ class TestIMAPConnection:
         conn = _bare_connection()
         with pytest.raises(NotImplementedError, match="IMAP"):
             conn.send_message("a@example.com")
+
+    def test_oauth2_kwargs_forwarded_to_client(self, monkeypatch):
+        captured = {}
+
+        def fake_imapclient_init(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(
+            "mailsuite.mailbox.imap.IMAPClient", fake_imapclient_init
+        )
+
+        def provider() -> str:
+            return "tok"
+
+        IMAPConnection(
+            "host",
+            "u@example.com",
+            oauth2_token_provider=provider,
+            oauth2_mechanism="OAUTHBEARER",
+        )
+        assert captured["oauth2_token_provider"] is provider
+        assert captured["oauth2_mechanism"] == "OAUTHBEARER"
+        assert captured["oauth2_token"] is None
+        assert captured["oauth2_vendor"] is None


### PR DESCRIPTION
## Summary

Closes #6. `mailsuite.imap.IMAPClient` and `mailsuite.mailbox.IMAPConnection` now support OAuth2 in addition to the existing username/password login.

For Google Workspace and Microsoft 365, the higher-level `GmailConnection` and `MSGraphConnection` backends remain the recommended path — they speak the providers' native APIs and handle token refresh end-to-end. Generic IMAP OAuth2 is the escape hatch for everyone else (Yahoo, self-hosted with OIDC, custom enterprise IMAP, etc.).

### New constructor kwargs

- `oauth2_token` — a static access token
- `oauth2_token_provider` — a zero-arg callable returning a current token. Re-invoked on every (re)connect, so long-running IDLE / watch loops survive token expiry. Recommended over `oauth2_token` for anything that stays connected.
- `oauth2_mechanism` — `"XOAUTH2"` (default — Gmail/Yahoo/M365) or `"OAUTHBEARER"` (Gmail's standards-track replacement)
- `oauth2_vendor` — optional vendor string required by Yahoo's XOAUTH2 implementation

`username` / `password` are now optional. Passing neither a password nor an OAuth2 token raises `ValueError`.

### Drive-by

- Fix the `IMAPClient` default port (was `933`, now the standard `993`).

### Example

```python
from mailsuite.mailbox import IMAPConnection

def get_token() -> str:
    # Refresh if needed and return a current access token
    return current_access_token()

conn = IMAPConnection(
    "imap.mail.yahoo.com",
    "alice@yahoo.com",
    oauth2_token_provider=get_token,
    oauth2_vendor="yahoo",
)
```

## Test plan

- [x] `pytest` — 233 passed (added `TestOAuth2Login` covering password vs OAuth dispatch, XOAUTH2 / OAUTHBEARER selection, Yahoo vendor pass-through, both `ValueError` paths, and token-provider re-invocation on `reset_connection()`)
- [x] `ruff check mailsuite tests`
- [x] `PYRIGHT_PYTHON_FORCE_VERSION=latest pyright mailsuite`
- [ ] Manual smoke test against a real OAuth2-enabled IMAP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)