### PR TITLE
Release 2.0.2: fix MSGraphConnection event loop and folder filter bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,60 @@ Don't add adjacent helpers, retry knobs, or precomputed fields the original
 lacked. Inline > extract; helpers earn their keep when called more than once.
 PR #22 history is the worst-case example to avoid re-creating.
 
+## Working with vendor SDKs
+
+When the question is "does the SDK do X?" or "what does the SDK return for
+Y?", **read the SDK source**. Don't guess, don't rely on a prior port's
+behavior, don't trust an LLM summary. Vendor SDKs change shape between
+versions and the installed version is the only contract that matters.
+
+In order of preference:
+
+1. The **installed SDK source** in `venv/lib/python.../site-packages/`.
+   `grep` and `inspect.getsource` answer most questions in seconds.
+2. The vendor's **official documentation** (Microsoft Learn, Google API
+   reference, etc.) for HTTP-level contracts the SDK wraps — error codes,
+   filter syntax, pagination semantics.
+3. The SDK's **GitHub issues** for known bugs and maintainer-recommended
+   patterns. Be wary of community workarounds in stale threads.
+
+Don't use parsedmarc, third-party blogs, or "what the original code did"
+as primary evidence. They're useful as "where to look next," not as a
+source of truth.
+
+### Lessons learned (Microsoft Graph SDK — `msgraph-sdk-python`)
+
+- **Retries are built-in.** `kiota_http`'s `RetryHandler` is part of the
+  default middleware pipeline (`max_retries=3`, exponential backoff on
+  `{429, 503, 504}`). Don't add an application-level retry layer; it's
+  redundant and competes with the SDK's behavior.
+- **Sync wrapper requires a persistent event loop.** The SDK is
+  async-only. `GraphRequestAdapter` holds a single `httpx.AsyncClient`
+  whose connection pool binds to the loop on first request — closing
+  that loop (e.g. via `asyncio.run` per call) invalidates the pool and
+  the next call surfaces as `RuntimeError: Event loop is closed`. Keep
+  one loop alive across calls (see `mailbox/graph.py:_run`). Microsoft
+  publishes no official sync-wrapper recipe; this is the
+  community-converged shape (see msgraph-sdk-python issues #366, #787,
+  #798).
+- **HTTP error detection: use `response_status_code`.** `ODataError`
+  inherits from `kiota_abstractions.api_error.APIError` and the
+  `response_status_code` attribute is set explicitly before raising
+  (see `kiota_http/httpx_request_adapter.py:throw_failed_responses`).
+  Check that, not the exception's string representation —
+  string-matching is fragile to error-message localization and SDK
+  changes.
+- **OData `$filter` strings need manual escaping.** The SDK provides no
+  helper. Per the [Graph query parameters
+  docs](https://learn.microsoft.com/en-us/graph/query-parameters),
+  single quotes inside string literals must be doubled (`'` → `''`).
+  Always escape user-supplied values before substituting into a
+  filter expression.
+- **The `with_url(next_link).get()` pattern follows OData pagination.**
+  Generated request builders expose `with_url(raw_url)` for following
+  `@odata.nextLink`. Kiota's `PageIterator` is an alternative but not
+  required.
+
 ## Optional extras (cloud backends)
 
 `MSGraphConnection` and `GmailConnection` are loaded lazily through PEP 562

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2
+
+- Fix `RuntimeError: Event loop is closed` in `MSGraphConnection` after the first Graph call. The internal `_run` helper used `asyncio.run`, which closed the event loop after each invocation; the Graph SDK's underlying `httpx.AsyncClient` keeps connection-pool resources bound to that loop, so the next call would fail. `_run` now retains a single persistent event loop across calls ([domainaware/parsedmarc#742](https://github.com/domainaware/parsedmarc/issues/742)).
+- Detect "folder already exists" in `MSGraphConnection.create_folder` by HTTP status code (`409 Conflict` on the SDK's `APIError.response_status_code`) rather than by string-matching the exception message. The previous string match was brittle to error-message localization and Graph SDK changes.
+- Escape single quotes in folder-name OData filters in `MSGraphConnection`. Folder names containing an apostrophe (e.g. `John's mail`) previously produced a malformed `displayName eq '…'` filter expression that Graph rejected.
+
 ## 2.0.1
 
 - Add OAuth2 (XOAUTH2 / OAUTHBEARER) login support to `mailsuite.imap.IMAPClient` and `mailsuite.mailbox.IMAPConnection`. Pass `oauth2_token=` for a static access token, or `oauth2_token_provider=` (a zero-arg callable) to have a fresh token fetched on every connect/reconnect — recommended for long-running watch / IDLE loops where tokens expire mid-session. Yahoo's vendor string is supported via `oauth2_vendor=`. Workspace and Microsoft 365 users should still prefer the higher-level `GmailConnection` / `MSGraphConnection` backends, which handle token refresh end-to-end (#6).

--- a/mailsuite/__init__.py
+++ b/mailsuite/__init__.py
@@ -1,3 +1,3 @@
 """A Python package to simplify receiving, parsing, and sending email"""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/mailsuite/mailbox/graph.py
+++ b/mailsuite/mailbox/graph.py
@@ -147,16 +147,35 @@ def _generate_credential(auth_method: str, token_path: Path, **kwargs):
     raise RuntimeError(f"Auth method {auth_method} not found")
 
 
+_persistent_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
 def _run(coro):
-    """Run a coroutine to completion. Refuses to nest in a running loop."""
+    """Run a coroutine to completion on a persistent event loop.
+
+    Refuses to nest in a running loop. We retain a single persistent
+    loop across calls because the Graph SDK's underlying
+    ``httpx.AsyncClient`` keeps connection-pool resources bound to the
+    loop that issued the first request — closing the loop between calls
+    (as ``asyncio.run`` does) invalidates those resources and surfaces
+    on the next call as ``RuntimeError: Event loop is closed``. See
+    https://github.com/domainaware/parsedmarc/issues/742.
+    """
+    global _persistent_loop
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        return asyncio.run(coro)
-    raise RuntimeError(
-        "MSGraphConnection cannot be called from inside a running event loop. "
-        "Use msgraph.GraphServiceClient directly from async code."
-    )
+        pass
+    else:
+        raise RuntimeError(
+            "MSGraphConnection cannot be called from inside a running event loop. "
+            "Use msgraph.GraphServiceClient directly from async code."
+        )
+
+    if _persistent_loop is None or _persistent_loop.is_closed():
+        _persistent_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_persistent_loop)
+    return _persistent_loop.run_until_complete(coro)
 
 
 class MSGraphConnection(MailboxConnection):
@@ -308,8 +327,7 @@ class MSGraphConnection(MailboxConnection):
                 )
             logger.debug("Created folder %s", folder_name)
         except Exception as e:
-            # 409 / "already exists" is normal — surface other errors
-            if "already exists" in str(e).lower() or "ErrorFolderExists" in str(e):
+            if getattr(e, "response_status_code", None) == 409:
                 logger.debug("Folder %s already exists, skipping", folder_name)
                 return
             raise
@@ -520,9 +538,11 @@ class MSGraphConnection(MailboxConnection):
     def _list_folders_filtered(
         self, folder_name: str, parent_folder_id: Optional[str]
     ) -> List[MailFolder]:
+        # OData string-literal escape: single quotes are doubled.
+        escaped = folder_name.replace("'", "''")
         if parent_folder_id is None:
             query = MailFoldersRequestBuilder.MailFoldersRequestBuilderGetQueryParameters(
-                filter=f"displayName eq '{folder_name}'"
+                filter=f"displayName eq '{escaped}'"
             )
             config = MailFoldersRequestBuilder.MailFoldersRequestBuilderGetRequestConfiguration(
                 query_parameters=query
@@ -534,7 +554,7 @@ class MSGraphConnection(MailboxConnection):
             )
         else:
             child_query = ChildFoldersRequestBuilder.ChildFoldersRequestBuilderGetQueryParameters(
-                filter=f"displayName eq '{folder_name}'"
+                filter=f"displayName eq '{escaped}'"
             )
             child_config = ChildFoldersRequestBuilder.ChildFoldersRequestBuilderGetRequestConfiguration(
                 query_parameters=child_query

--- a/tests/test_mailbox_graph.py
+++ b/tests/test_mailbox_graph.py
@@ -86,6 +86,7 @@ class FakeMailFolders:
         self.posts = []
         self._items: dict = {}
         self._listing_pages = []
+        self.get_calls = []
 
     def by_mail_folder_id(self, fid):
         if fid not in self._items:
@@ -93,6 +94,7 @@ class FakeMailFolders:
         return self._items[fid]
 
     def get(self, request_configuration=None):
+        self.get_calls.append(request_configuration)
         if self._listing_pages:
             return _coro(self._listing_pages.pop(0))
         return _coro(MagicMock(value=[]))
@@ -191,6 +193,23 @@ class TestRunHelper:
                 _run(asyncio.sleep(0))
 
         asyncio.run(main())
+
+    def test_reuses_loop_across_calls(self):
+        """Regression for parsedmarc#742. ``_run`` must reuse a single
+        persistent event loop across calls; closing the loop (as
+        ``asyncio.run`` did) leaves the Graph SDK's httpx connection
+        pool bound to a closed loop, surfacing as ``RuntimeError: Event
+        loop is closed`` on the next request."""
+        loops_seen = []
+
+        async def capture_loop():
+            loops_seen.append(asyncio.get_running_loop())
+
+        _run(capture_loop())
+        _run(capture_loop())
+
+        assert loops_seen[0] is loops_seen[1]
+        assert not loops_seen[0].is_closed()
 
 
 class TestAuthMethodNames:
@@ -333,6 +352,19 @@ class TestFolderResolution:
         with pytest.raises(RuntimeError, match="not found"):
             conn._find_folder_id_from_folder_path("DoesNotExist")
 
+    def test_odata_single_quote_escaping(self):
+        """Folder names containing apostrophes must escape them per OData
+        rules (single quote → two single quotes), or the filter expression
+        is malformed and Graph rejects the request."""
+        conn = _make_conn()
+        folders = conn._client.users.by_user_id("x").mail_folders
+        folders._listing_pages = [
+            MagicMock(value=[MagicMock(id="id1", display_name="John's mail")]),
+        ]
+        assert conn._find_folder_id_from_folder_path("John's mail") == "id1"
+        config = folders.get_calls[0]
+        assert config.query_parameters.filter == "displayName eq 'John''s mail'"
+
     def test_well_known_folder_fallback(self):
         conn = _make_conn()
         # Empty listing for the literal name…
@@ -362,12 +394,17 @@ class TestCreateFolder:
 
     def test_already_exists_swallowed(self):
         conn = _make_conn()
-        # Make post raise an "already exists" error
+
+        # Graph returns 409 Conflict when a folder with the same display
+        # name already exists. The SDK surfaces it as an APIError-derived
+        # exception with response_status_code == 409.
+        class FakeAPIError(Exception):
+            response_status_code = 409
+
         async def _raise(*a, **k):
-            raise RuntimeError("ErrorFolderExists: yep")
+            raise FakeAPIError("Conflict")
 
         conn._client.users.by_user_id("x").mail_folders.post = lambda body: _raise()
-        # Should not raise
         conn.create_folder("Reports")
 
     def test_unknown_error_propagates(self):


### PR DESCRIPTION
## Summary

- Fix `RuntimeError: Event loop is closed` in `MSGraphConnection` after the first Graph call ([domainaware/parsedmarc#742](https://github.com/domainaware/parsedmarc/issues/742)). `_run` retained `asyncio.run` per call, which closed the loop each time; the Graph SDK's underlying `httpx.AsyncClient` keeps connection-pool resources bound to that loop, so the next call surfaced as "Event loop is closed". `_run` now keeps a single persistent loop across calls.
- Detect "folder already exists" in `create_folder` by HTTP status (`APIError.response_status_code == 409`) instead of string-matching the exception message. The previous string match was brittle to error-message localization and SDK changes.
- Escape single quotes in folder-name OData filters in `_list_folders_filtered` (`'` → `''`) per [Microsoft Graph $filter docs](https://learn.microsoft.com/en-us/graph/query-parameters). Folders with apostrophes (e.g. `John's mail`) previously produced a malformed `displayName eq '...'` expression that Graph rejected.
- Add a new *Working with vendor SDKs* section to `AGENTS.md` codifying the SDK-source-as-truth principle and the Graph-specific lessons from this PR (built-in retry middleware, persistent-event-loop requirement, `response_status_code` for HTTP error detection, OData filter escaping, `with_url(next_link).get()` for pagination).

Bumps version to `2.0.2`.

## Audit notes

Verified all three fixes against the SDK source (kiota_http / msgraph) and Microsoft Learn docs:
- Persistent loop: `GraphRequestAdapter` holds a single `httpx.AsyncClient` whose connection pool binds to the loop on first request; closing the loop invalidates the pool. No Microsoft-blessed sync-wrapper recipe exists ([msgraph-sdk-python#366](https://github.com/microsoftgraph/msgraph-sdk-python/issues/366), [#787](https://github.com/microsoftgraph/msgraph-sdk-python/issues/787), [#798](https://github.com/microsoftgraph/msgraph-sdk-python/issues/798)); persistent loop matches the community-converged shape.
- 409 detection: kiota's `throw_failed_responses` explicitly sets `error.response_status_code = response.status_code` before raising; verified at `kiota_http/httpx_request_adapter.py:563`.
- OData escape: end-to-end-verified that `displayName eq 'John''s mail'` URL-encodes to a valid query and the server decodes back to OData-conformant form.

The SDK already provides retry middleware (`kiota_http.middleware.retry_handler.RetryHandler`, default `max_retries=3` with exponential backoff on `{429, 503, 504}`), so no application-level retry layer is needed. This is one of the lessons captured in the new AGENTS.md section.

## Test plan

- [x] `pytest` — 234 tests pass
- [x] `ruff check mailsuite tests` — clean
- [x] `PYRIGHT_PYTHON_FORCE_VERSION=latest pyright mailsuite` — clean
- [x] New regression tests added: `_run` reuses the same loop across calls; OData single-quote escape verified via captured filter; 409 detection driven by `response_status_code` attribute on a fake `APIError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)