### PR TITLE
Close persistent Graph event loop at interpreter shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Close the persistent event loop in `mailsuite.mailbox.graph` at interpreter shutdown via `atexit`. Prevents a `ResourceWarning: unclosed event loop` under `-W error` / `PYTHONDEVMODE=1` after the 2.0.2 fix retained the loop across calls.
+
 ## 2.0.2
 
 - Fix `RuntimeError: Event loop is closed` in `MSGraphConnection` after the first Graph call. The internal `_run` helper used `asyncio.run`, which closed the event loop after each invocation; the Graph SDK's underlying `httpx.AsyncClient` keeps connection-pool resources bound to that loop, so the next call would fail. `_run` now retains a single persistent event loop across calls ([domainaware/parsedmarc#742](https://github.com/domainaware/parsedmarc/issues/742)).

--- a/mailsuite/mailbox/graph.py
+++ b/mailsuite/mailbox/graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 from enum import Enum
 from functools import lru_cache
@@ -176,6 +177,14 @@ def _run(coro):
         _persistent_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(_persistent_loop)
     return _persistent_loop.run_until_complete(coro)
+
+
+@atexit.register
+def _close_persistent_loop() -> None:
+    global _persistent_loop
+    if _persistent_loop is not None and not _persistent_loop.is_closed():
+        _persistent_loop.close()
+    _persistent_loop = None
 
 
 class MSGraphConnection(MailboxConnection):


### PR DESCRIPTION
## Summary
- After 2.0.2, `mailsuite.mailbox.graph._run` retains a single `asyncio` event loop across calls so the Graph SDK's `httpx.AsyncClient` connection pool stays valid. The loop was never closed at interpreter shutdown, which can emit `ResourceWarning: unclosed event loop` under `-W error` or `PYTHONDEVMODE=1`.
- Register an `atexit` handler that closes `_persistent_loop` if it is still open. Behavior in normal use is unchanged; this just tidies shutdown.

## Test plan
- [x] `ruff check mailsuite/mailbox/graph.py`
- [x] `PYRIGHT_PYTHON_FORCE_VERSION=latest pyright mailsuite/mailbox/graph.py`
- [x] `pytest tests/test_mailbox_graph.py` (41 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)