### PR TITLE
MSGraphConnection: add support for ClientAssertion (OAuth2) credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `ClientAssertion` auth to `MSGraphConnection` for federated / workload-identity scenarios that avoid a long-lived client secret. Pass `client_assertion=` with a signed-JWT assertion, or `client_assertion_provider=` (a zero-arg callable) to supply a fresh assertion each time `azure-identity` acquires a token. The assertion is exchanged for an access token via the JWT-bearer client-credentials grant — it is not itself a Graph access token (#31).
+
 ## 2.1.0
 
 - Expand the `MailboxConnection` folder-management API across the IMAP, Maildir, Microsoft Graph, and Gmail backends, supporting folder migrations such as renaming or merging a legacy folder into its replacement:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ mailbox, grant `Mail.ReadWrite` and `Mail.Send`.
 
 Delegated flows (`DeviceCode`, `UsernamePassword`) targeting a shared
 mailbox — i.e. when the `mailbox` argument differs from `username` —
-use the `.Shared` variants. App-only flows (`ClientSecret`,
+use the `.Shared` variants. App-only flows (`ClientAssertion`, `ClientSecret`,
 `Certificate`) do not need the `.Shared` variants since application
 permissions span every mailbox in the tenant (unless restricted by an
 [Application Access Policy](https://learn.microsoft.com/en-us/graph/auth-limit-mailbox-access)).

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ mailbox, grant `Mail.ReadWrite` and `Mail.Send`.
 
 Delegated flows (`DeviceCode`, `UsernamePassword`) targeting a shared
 mailbox — i.e. when the `mailbox` argument differs from `username` —
-use the `.Shared` variants. App-only flows (`ClientSecret`,
+use the `.Shared` variants. App-only flows (`ClientAssertion`, `ClientSecret`,
 `Certificate`) do not need the `.Shared` variants since application
 permissions span every mailbox in the tenant (unless restricted by an
 [Application Access Policy](https://learn.microsoft.com/en-us/graph/auth-limit-mailbox-access)).

--- a/mailsuite/mailbox/graph.py
+++ b/mailsuite/mailbox/graph.py
@@ -17,6 +17,7 @@ try:
     from azure.identity import (
         AuthenticationRecord,
         CertificateCredential,
+        ClientAssertionCredential,
         ClientSecretCredential,
         DeviceCodeCredential,
         TokenCachePersistenceOptions,
@@ -67,6 +68,7 @@ class AuthMethod(Enum):
     UsernamePassword = 2
     ClientSecret = 3
     Certificate = 4
+    ClientAssertion = 5
 
 
 DEFAULT_TOKEN_CACHE_NAME = "mailsuite"
@@ -129,6 +131,12 @@ def _generate_credential(auth_method: str, token_path: Path, **kwargs):
                 allow_unencrypted_storage=kwargs["allow_unencrypted_storage"],
                 cache_name=cache_name,
             ),
+        )
+    if auth_method == AuthMethod.ClientAssertion.name:
+        return ClientAssertionCredential(
+            tenant_id=kwargs["tenant_id"],
+            client_id=kwargs["client_id"],
+            func=kwargs["oauth2_token_provider"],
         )
     if auth_method == AuthMethod.ClientSecret.name:
         return ClientSecretCredential(
@@ -194,10 +202,10 @@ class MSGraphConnection(MailboxConnection):
     """
     A :class:`MailboxConnection` backed by Microsoft Graph
 
-    Supports DeviceCode, UsernamePassword, ClientSecret, and Certificate
-    auth via :mod:`azure.identity`. Send mail goes through
-    ``/users/{mailbox}/sendMail`` with a structured ``Message`` body
-    (Graph automatically saves a copy to Sent Items).
+    Supports DeviceCode, UsernamePassword, ClientSecret, ClientAssertion
+    (OAuth2) and Certificate auth via :mod:`azure.identity`. Send mail
+    goes through ``/users/{mailbox}/sendMail`` with a structured ``Message``
+    body (Graph automatically saves a copy to Sent Items).
 
     Required Microsoft Graph **API permissions** on the app registration
     (combine as needed):
@@ -210,7 +218,7 @@ class MSGraphConnection(MailboxConnection):
     Delegated flows (``DeviceCode``, ``UsernamePassword``) targeting a
     shared mailbox (i.e. ``mailbox != username``) use the ``.Shared``
     variants — ``Mail.Read.Shared``, ``Mail.ReadWrite.Shared``,
-    ``Mail.Send.Shared``. App-only flows (``ClientSecret``,
+    ``Mail.Send.Shared``. App-only flows (``ClientSecret``, ``ClientAssertion``
     ``Certificate``) do not need the ``.Shared`` variants. See the
     README "Microsoft Graph permissions" section for the full mapping.
 
@@ -247,6 +255,8 @@ class MSGraphConnection(MailboxConnection):
         certificate_password: Optional[Union[str, bytes]] = None,
         graph_url: Optional[str] = None,
         token_cache_name: str = DEFAULT_TOKEN_CACHE_NAME,
+        oauth2_token: Optional[str] = None,
+        oauth2_token_provider: Optional[Callable[[], str]] = None,
     ):
         """
         Args:
@@ -272,8 +282,18 @@ class MSGraphConnection(MailboxConnection):
                 from a previous installation can pass the old cache name
                 (e.g. ``"parsedmarc"``) so existing cached
                 ``AuthenticationRecord``s and tokens continue to work.
+            oauth2_token: A static OAuth2 access token for ClientAssertion
+                auth. For long-running connections prefer
+                ``oauth2_token_provider`` so a fresh token is fetched on
+                reconnect.
+            oauth2_token_provider: A zero-arg callable returning a current
+                OAuth2 access token. Invoked on every (re)connect, so the
+                callable is responsible for refreshing the token when
+                needed.
         """
         token_path = Path(token_file)
+        if oauth2_token_provider is None and oauth2_token is not None:
+            oauth2_token_provider = lambda: oauth2_token
         credential = _generate_credential(
             auth_method,
             client_id=client_id,
@@ -286,10 +306,12 @@ class MSGraphConnection(MailboxConnection):
             token_path=token_path,
             allow_unencrypted_storage=allow_unencrypted_storage,
             cache_name=token_cache_name,
+            oauth2_token_provider=oauth2_token_provider,
         )
 
         scopes: Optional[List[str]] = None
-        if not isinstance(credential, (ClientSecretCredential, CertificateCredential)):
+        if not isinstance(credential, (ClientAssertionCredential, ClientSecretCredential,
+                                       CertificateCredential)):
             scopes = ["Mail.ReadWrite"]
             # Detect if mailbox is shared
             if mailbox and username and username != mailbox:

--- a/mailsuite/mailbox/graph.py
+++ b/mailsuite/mailbox/graph.py
@@ -133,10 +133,16 @@ def _generate_credential(auth_method: str, token_path: Path, **kwargs):
             ),
         )
     if auth_method == AuthMethod.ClientAssertion.name:
+        provider = kwargs.get("client_assertion_provider")
+        if provider is None:
+            raise ValueError(
+                "client_assertion or client_assertion_provider is required "
+                "when auth_method is 'ClientAssertion'"
+            )
         return ClientAssertionCredential(
             tenant_id=kwargs["tenant_id"],
             client_id=kwargs["client_id"],
-            func=kwargs["oauth2_token_provider"],
+            func=provider,
         )
     if auth_method == AuthMethod.ClientSecret.name:
         return ClientSecretCredential(
@@ -202,10 +208,10 @@ class MSGraphConnection(MailboxConnection):
     """
     A :class:`MailboxConnection` backed by Microsoft Graph
 
-    Supports DeviceCode, UsernamePassword, ClientSecret, ClientAssertion
-    (OAuth2) and Certificate auth via :mod:`azure.identity`. Send mail
-    goes through ``/users/{mailbox}/sendMail`` with a structured ``Message``
-    body (Graph automatically saves a copy to Sent Items).
+    Supports DeviceCode, UsernamePassword, ClientSecret, ClientAssertion,
+    and Certificate auth via :mod:`azure.identity`. Send mail goes through
+    ``/users/{mailbox}/sendMail`` with a structured ``Message`` body (Graph
+    automatically saves a copy to Sent Items).
 
     Required Microsoft Graph **API permissions** on the app registration
     (combine as needed):
@@ -218,9 +224,10 @@ class MSGraphConnection(MailboxConnection):
     Delegated flows (``DeviceCode``, ``UsernamePassword``) targeting a
     shared mailbox (i.e. ``mailbox != username``) use the ``.Shared``
     variants — ``Mail.Read.Shared``, ``Mail.ReadWrite.Shared``,
-    ``Mail.Send.Shared``. App-only flows (``ClientSecret``, ``ClientAssertion``
-    ``Certificate``) do not need the ``.Shared`` variants. See the
-    README "Microsoft Graph permissions" section for the full mapping.
+    ``Mail.Send.Shared``. App-only flows (``ClientSecret``,
+    ``ClientAssertion``, ``Certificate``) do not need the ``.Shared``
+    variants. See the README "Microsoft Graph permissions" section for the
+    full mapping.
 
     Note: delegated flows always request ``Mail.ReadWrite`` at
     authenticate time, so even read-only callers must consent to at
@@ -255,8 +262,8 @@ class MSGraphConnection(MailboxConnection):
         certificate_password: Optional[Union[str, bytes]] = None,
         graph_url: Optional[str] = None,
         token_cache_name: str = DEFAULT_TOKEN_CACHE_NAME,
-        oauth2_token: Optional[str] = None,
-        oauth2_token_provider: Optional[Callable[[], str]] = None,
+        client_assertion: Optional[str] = None,
+        client_assertion_provider: Optional[Callable[[], str]] = None,
     ):
         """
         Args:
@@ -282,18 +289,27 @@ class MSGraphConnection(MailboxConnection):
                 from a previous installation can pass the old cache name
                 (e.g. ``"parsedmarc"``) so existing cached
                 ``AuthenticationRecord``s and tokens continue to work.
-            oauth2_token: A static OAuth2 access token for ClientAssertion
-                auth. For long-running connections prefer
-                ``oauth2_token_provider`` so a fresh token is fetched on
-                reconnect.
-            oauth2_token_provider: A zero-arg callable returning a current
-                OAuth2 access token. Invoked on every (re)connect, so the
-                callable is responsible for refreshing the token when
-                needed.
+            client_assertion: A static client assertion for ClientAssertion
+                auth — a signed JWT (e.g. a federated credential) that
+                ``azure-identity`` exchanges for an access token via the
+                JWT-bearer client-credentials grant, *not* a Graph access
+                token. For long-running connections prefer
+                ``client_assertion_provider`` so a fresh assertion is
+                available when the credential needs a new token.
+            client_assertion_provider: A zero-arg callable returning a
+                current client assertion (signed JWT).
+                :class:`~azure.identity.ClientAssertionCredential` calls it
+                each time it acquires a new access token, so the callable is
+                responsible for returning a valid (unexpired) assertion.
         """
         token_path = Path(token_file)
-        if oauth2_token_provider is None and oauth2_token is not None:
-            oauth2_token_provider = lambda: oauth2_token
+        if client_assertion is not None and client_assertion_provider is None:
+            static_assertion = client_assertion
+
+            def _static_assertion_provider() -> str:
+                return static_assertion
+
+            client_assertion_provider = _static_assertion_provider
         credential = _generate_credential(
             auth_method,
             client_id=client_id,
@@ -306,7 +322,7 @@ class MSGraphConnection(MailboxConnection):
             token_path=token_path,
             allow_unencrypted_storage=allow_unencrypted_storage,
             cache_name=token_cache_name,
-            oauth2_token_provider=oauth2_token_provider,
+            client_assertion_provider=client_assertion_provider,
         )
 
         scopes: Optional[List[str]] = None

--- a/tests/test_mailbox_graph.py
+++ b/tests/test_mailbox_graph.py
@@ -254,6 +254,29 @@ class TestAuthMethodNames:
                 tenant_id="t",
             )
 
+    def test_client_assertion_wires_provider(self, tmp_path):
+        from azure.identity import ClientAssertionCredential
+
+        cred = _generate_credential(
+            AuthMethod.ClientAssertion.name,
+            tmp_path / "tok",
+            client_id="c",
+            tenant_id="t",
+            client_assertion_provider=lambda: "the-assertion",
+        )
+        assert isinstance(cred, ClientAssertionCredential)
+        # The credential calls func() to obtain the assertion it exchanges.
+        assert cred._func() == "the-assertion"
+
+    def test_client_assertion_requires_provider(self, tmp_path):
+        with pytest.raises(ValueError, match="client_assertion"):
+            _generate_credential(
+                AuthMethod.ClientAssertion.name,
+                tmp_path / "tok",
+                client_id="c",
+                tenant_id="t",
+            )
+
 
 class TestSubclass:
     def test_is_mailbox_connection(self):
@@ -670,6 +693,60 @@ class TestGraphUrl:
         base = str(conn._client.request_adapter._http_client.base_url)
         assert url.rstrip("/") in base
         assert base.endswith("/v1.0") or base.endswith("/v1.0/")
+
+
+class TestClientAssertionAuth:
+    """ClientAssertion wraps a static assertion and skips ``authenticate()``."""
+
+    def _build(self, monkeypatch, **kwargs):
+        # ClientAssertionCredential is app-only and has no authenticate();
+        # the constructor must branch on its type to skip that step. Capture
+        # the provider that __init__ forwards to _generate_credential.
+        from azure.identity import ClientAssertionCredential
+        from mailsuite.mailbox import graph as graph_mod
+
+        captured = {}
+
+        class FakeCred(ClientAssertionCredential):
+            def __init__(self):
+                pass  # bypass real Azure SDK init
+
+            def authenticate(self, *a, **k):  # pragma: no cover
+                raise AssertionError("authenticate() must not run for app-only auth")
+
+            def get_token(self, *a, **k):
+                return None
+
+        def fake_generate(auth_method, token_path, **kw):
+            captured["provider"] = kw.get("client_assertion_provider")
+            return FakeCred()
+
+        monkeypatch.setattr(graph_mod, "_generate_credential", fake_generate)
+        conn = MSGraphConnection(
+            auth_method=AuthMethod.ClientAssertion.name,
+            mailbox="user@example.com",
+            client_id="c",
+            client_secret=None,
+            username=None,
+            password=None,
+            tenant_id="t",
+            token_file="/tmp/unused-token",
+            allow_unencrypted_storage=False,
+            graph_url="https://graph.example.test",
+            **kwargs,
+        )
+        return conn, captured
+
+    def test_static_assertion_wrapped_in_provider(self, monkeypatch):
+        # A static client_assertion is turned into a zero-arg provider.
+        _, captured = self._build(monkeypatch, client_assertion="abc")
+        assert captured["provider"]() == "abc"
+
+    def test_skips_authenticate(self, monkeypatch):
+        # FakeCred.authenticate() raises if reached; a clean build proves the
+        # isinstance branch excludes ClientAssertion from authenticate().
+        conn, _ = self._build(monkeypatch, client_assertion="abc")
+        assert conn.mailbox_name == "user@example.com"
 
 
 class TestCacheName:


### PR DESCRIPTION
This is useful for federated cloud settings without resorting to a long-lived secret.

The implementation is just plumbing, with one minor feature (based on the IMAP code) to allow passing a static one-time token short-lived operations.