### PR TITLE
Fix from_trusted_domain crash on multiple Authentication-Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Pass `oauth2_token=` (or `oauth2_token_provider=` for a fresh token at send time) with `username=` to authenticate without a password.
   - `oauth2_mechanism=` selects `XOAUTH2` (default) or `OAUTHBEARER`; `oauth2_vendor=` supplies Yahoo's vendor string.
 - Add `ClientAssertion` auth to `MSGraphConnection` for federated / workload-identity scenarios that avoid a long-lived client secret. Pass `client_assertion=` with a signed-JWT assertion, or `client_assertion_provider=` (a zero-arg callable) to supply a fresh assertion each time `azure-identity` acquires a token. The assertion is exchanged for an access token via the JWT-bearer client-credentials grant — it is not itself a Graph access token (#31).
+- Fix `from_trusted_domain()` raising `TypeError` when `allow_multiple_authentication_results=True` and the message carries multiple `Authentication-Results` headers (which `parse_email` represents as raw strings). Each header is now parsed before inspection, and the matched DMARC domain is lower-cased/stripped to match the single-header path.
 
 ## 2.1.0
 

--- a/mailsuite/utils.py
+++ b/mailsuite/utils.py
@@ -596,23 +596,30 @@ def from_trusted_domain(
                     return True
         return False
     if isinstance(results, list) and allow_multiple_authentication_results:
-        dmarc_result = False
         dmarc = None
         for header in results:
-            if "dmarc" in header:
-                if dmarc is not None:
-                    return False
-                dmarc = header["dmarc"]
-                dmarc_result = dmarc["result"]
-                domain = dmarc["header.from"]
-                sld = publicsuffix2.get_sld(domain)
-                if dmarc_result == "pass" and domain in trusted_domains:
-                    dmarc_result = True
-                    return dmarc_result
-                if include_sld:
-                    if dmarc_result == "pass" and sld in trusted_domains:
-                        dmarc_result = True
-                        return dmarc_result
+            # parse_email yields raw strings for multiple Authentication-Results
+            # headers; parse each into the same dict shape as the single-header
+            # path before inspecting it.
+            if isinstance(header, str):
+                try:
+                    header = parse_authentication_results(header)
+                except ValueError:
+                    continue
+            if not isinstance(header, dict) or "dmarc" not in header:
+                continue
+            if dmarc is not None:
+                # More than one DMARC result across the headers is ambiguous
+                return False
+            dmarc = header["dmarc"]
+            if dmarc.get("result") != "pass" or "header.from" not in dmarc:
+                continue
+            domain = dmarc["header.from"].lower().strip()
+            sld = publicsuffix2.get_sld(domain)
+            if domain in trusted_domains:
+                return True
+            if include_sld and sld in trusted_domains:
+                return True
     return False
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -303,3 +303,124 @@ class TestFromTrustedDomain:
         msg = self._msg_with_dmarc_pass("example.com")
         parsed = parse_email(msg)
         assert from_trusted_domain(parsed, ["example.com"]) is True
+
+    # — DMARC-only dict path (existing tests match via the DKIM branch) —
+
+    def _msg_dmarc_only(self, domain: str = "example.com") -> str:
+        return (
+            f"From: a@{domain}\r\n"
+            "To: b@example.org\r\n"
+            f"Authentication-Results: mx.example.org; dmarc=pass header.from={domain}\r\n"
+            "Subject: hi\r\n\r\nbody\r\n"
+        )
+
+    def test_dmarc_only_trusted(self):
+        assert from_trusted_domain(self._msg_dmarc_only("example.com"), ["example.com"]) is True
+
+    def test_dmarc_only_untrusted(self):
+        assert from_trusted_domain(self._msg_dmarc_only("evil.example"), ["example.com"]) is False
+
+    def test_dmarc_only_sld(self):
+        msg = self._msg_dmarc_only("mail.example.com")
+        assert from_trusted_domain(msg, ["example.com"], include_sld=True) is True
+
+    # — multiple Authentication-Results headers —
+
+    def _msg_multi_ar(self, *ar_results: str) -> str:
+        headers = "".join(
+            f"Authentication-Results: mx.example.org; {r}\r\n" for r in ar_results
+        )
+        return (
+            "From: a@example.com\r\nTo: b@example.org\r\n"
+            f"{headers}Subject: hi\r\n\r\nbody\r\n"
+        )
+
+    def test_multiple_results_trusted(self):
+        # Regression: this used to raise TypeError because parse_email returns
+        # raw strings (not dicts) for multiple Authentication-Results headers.
+        msg = self._msg_multi_ar(
+            "spf=pass smtp.mailfrom=example.com",
+            "dmarc=pass header.from=example.com",
+        )
+        assert (
+            from_trusted_domain(
+                msg, ["example.com"], allow_multiple_authentication_results=True
+            )
+            is True
+        )
+
+    def test_multiple_results_untrusted(self):
+        msg = self._msg_multi_ar(
+            "spf=pass smtp.mailfrom=evil.example",
+            "dmarc=pass header.from=evil.example",
+        )
+        assert (
+            from_trusted_domain(
+                msg, ["example.com"], allow_multiple_authentication_results=True
+            )
+            is False
+        )
+
+    def test_multiple_results_sld(self):
+        msg = self._msg_multi_ar(
+            "spf=pass smtp.mailfrom=mail.example.com",
+            "dmarc=pass header.from=mail.example.com",
+        )
+        assert (
+            from_trusted_domain(
+                msg,
+                ["example.com"],
+                include_sld=True,
+                allow_multiple_authentication_results=True,
+            )
+            is True
+        )
+
+    def test_multiple_results_requires_flag(self):
+        # Without the opt-in flag, multiple AR headers are not consulted
+        msg = self._msg_multi_ar(
+            "spf=pass smtp.mailfrom=example.com",
+            "dmarc=pass header.from=example.com",
+        )
+        assert from_trusted_domain(msg, ["example.com"]) is False
+
+    def test_multiple_results_two_dmarc_rejected(self):
+        # Two DMARC stamps across the headers is ambiguous and rejected, even
+        # though one of them is trusted.
+        msg = self._msg_multi_ar(
+            "dmarc=pass header.from=other.example",
+            "dmarc=pass header.from=example.com",
+        )
+        assert (
+            from_trusted_domain(
+                msg, ["example.com"], allow_multiple_authentication_results=True
+            )
+            is False
+        )
+
+    # — Authentication-Results-Original (Proofpoint / Cisco gateways) —
+
+    def _msg_ar_original(self) -> str:
+        return (
+            "From: a@example.com\r\nTo: b@example.org\r\n"
+            "Authentication-Results: mx.example.org; "
+            "dmarc=fail header.from=spoof.example\r\n"
+            "Authentication-Results-Original: gw.example.org; "
+            "dmarc=pass header.from=example.com\r\n"
+            "Subject: hi\r\n\r\nbody\r\n"
+        )
+
+    def test_authentication_results_original_used(self):
+        # With the flag, the -Original header (dmarc=pass example.com) is used
+        msg = self._msg_ar_original()
+        assert (
+            from_trusted_domain(
+                msg, ["example.com"], use_authentication_results_original=True
+            )
+            is True
+        )
+
+    def test_authentication_results_original_ignored_by_default(self):
+        # Without the flag, the regular header (dmarc=fail spoof.example) is used
+        msg = self._msg_ar_original()
+        assert from_trusted_domain(msg, ["example.com"]) is False


### PR DESCRIPTION
## Bug

When `allow_multiple_authentication_results=True` and a message carries more than one `Authentication-Results` header, `parse_email` represents them as a list of **raw strings**, but `from_trusted_domain`'s list branch indexed each element as a dict (`header["dmarc"]`), raising `TypeError: string indices must be integers`. Downstream callers reach this via e.g. yaramail's `--multi-auth`; the existing tests only exercised single `Authentication-Results` / `Authentication-Results-Original` headers, so it was latent.

## Fix

Parse each entry with `parse_authentication_results` before inspecting it, skip non-dict/unparseable entries, and lower-case/strip the matched DMARC domain to match the single-header path.

## Tests

Adds the multiple-results path (trusted, untrusted, SLD, the two-DMARC ambiguity guard, opt-in flag), plus the previously untested DMARC-only dict path and the `Authentication-Results-Original` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)