### PR TITLE
Fix send_email() not delivering to Cc and Bcc recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Pass `oauth2_token=` (or `oauth2_token_provider=` for a fresh token at send time) with `username=` to authenticate without a password.
   - `oauth2_mechanism=` selects `XOAUTH2` (default) or `OAUTHBEARER`; `oauth2_vendor=` supplies Yahoo's vendor string.
 - Add `ClientAssertion` auth to `MSGraphConnection` for federated / workload-identity scenarios that avoid a long-lived client secret. Pass `client_assertion=` with a signed-JWT assertion, or `client_assertion_provider=` (a zero-arg callable) to supply a fresh assertion each time `azure-identity` acquires a token. The assertion is exchanged for an access token via the JWT-bearer client-credentials grant — it is not itself a Graph access token (#31).
+- Fix `mailsuite.smtp.send_email()` not delivering to `Cc` and `Bcc` recipients. The SMTP envelope was built from `message_to` only — Cc/Bcc were appended after the envelope was captured — so the MTA delivered to the `To` addresses alone. The envelope now includes every recipient, and the caller's recipient lists are no longer mutated in place.
 
 ## 2.1.0
 

--- a/mailsuite/smtp.py
+++ b/mailsuite/smtp.py
@@ -175,13 +175,16 @@ def send_email(
             server.login(username, password)
         if envelope_from is None:
             envelope_from = message_from
-        if message_to is None and message_to is None:
-            raise ValueError("message_to and envelope_to cannot both be None")
-        envelope_to = message_to.copy()
+        if message_to is None:
+            raise ValueError("message_to cannot be None")
+        # The SMTP envelope must list every recipient — To, Cc, and Bcc — or
+        # the omitted ones never receive the message. (Bcc is intentionally
+        # absent from the message headers, so the envelope is its only path.)
+        envelope_to = list(message_to)
         if message_cc is not None:
-            message_to += message_cc
+            envelope_to += message_cc
         if message_bcc is not None:
-            message_to += message_bcc
+            envelope_to += message_bcc
         envelope_to = list(set(envelope_to))
         server.sendmail(envelope_from, envelope_to, msg)
     except smtplib.SMTPException as error:

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -162,8 +162,29 @@ class TestSendEmailBasic:
             message_bcc=["d@example.org"],
         )
         _, recipients, body = fake_smtp.instances[-1].sendmail_args
-        # Cc must appear in the envelope (not necessarily in the To header)
-        assert "c@example.org" in recipients or "c@example.org" in body
+        # Every recipient — To, Cc, and Bcc — must be in the SMTP envelope, or
+        # the omitted ones never receive the message.
+        assert "b@example.org" in recipients
+        assert "c@example.org" in recipients
+        assert "d@example.org" in recipients
+        # Bcc must not leak into the message headers
+        assert "d@example.org" not in body
+
+    def test_recipient_lists_not_mutated(self, fake_smtp):
+        # Building the envelope must not mutate the caller's lists in place
+        to = ["b@example.org"]
+        cc = ["c@example.org"]
+        bcc = ["d@example.org"]
+        send_email(
+            host="smtp.example.com",
+            message_from="a@example.com",
+            message_to=to,
+            message_cc=cc,
+            message_bcc=bcc,
+        )
+        assert to == ["b@example.org"]
+        assert cc == ["c@example.org"]
+        assert bcc == ["d@example.org"]
 
 
 class TestSendEmailOAuth:


### PR DESCRIPTION
## Bug

`send_email`'s SMTP envelope was snapshotted from `message_to` **before** Cc/Bcc were appended, and the appends went to `message_to` (already consumed by `create_email`). So the envelope passed to `sendmail()` contained only the `To` addresses: Cc recipients appeared in the `Cc:` header but never received the message, and Bcc recipients received nothing.

## Fix

Build the envelope from To + Cc + Bcc (deduplicated) without mutating the caller's lists, and drop the redundant `message_to is None and message_to is None` guard (whose error message referenced a nonexistent `envelope_to` parameter).

## Tests

The existing test passed only because it checked the Cc address against the message body (the `Cc:` header) rather than the envelope. It now asserts every recipient is in the envelope and that Bcc stays out of the headers, plus a test that the caller's lists aren't mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)