### PR TITLE
Fix parse_email reply-to/subject bugs and address type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   - Pass `oauth2_token=` (or `oauth2_token_provider=` for a fresh token at send time) with `username=` to authenticate without a password.
   - `oauth2_mechanism=` selects `XOAUTH2` (default) or `OAUTHBEARER`; `oauth2_vendor=` supplies Yahoo's vendor string.
 - Add `ClientAssertion` auth to `MSGraphConnection` for federated / workload-identity scenarios that avoid a long-lived client secret. Pass `client_assertion=` with a signed-JWT assertion, or `client_assertion_provider=` (a zero-arg callable) to supply a fresh assertion each time `azure-identity` acquires a token. The assertion is exchanged for an access token via the JWT-bearer client-credentials grant — it is not itself a Graph access token (#31).
+- Fix several `mailsuite.utils` parsing bugs:
+  - `parse_email()` always returned `reply-to` as `[]`, discarding the parsed Reply-To addresses; they are now preserved.
+  - `parse_email()` raised `re.error` (or corrupted `headers_string`) when the `Subject` or `Thread-Topic` contained a backslash sequence such as `\1`; the value is now inserted literally.
+  - `parse_email_address()` raised `UnboundLocalError` on input that was neither a `str` nor a tuple; it now raises a clear `TypeError`.
 
 ## 2.1.0
 

--- a/mailsuite/utils.py
+++ b/mailsuite/utils.py
@@ -88,6 +88,8 @@ def parse_email_address(email_address: Union[tuple, str]) -> dict:
             )
     elif isinstance(email_address, tuple):
         parsed_address = email_address
+    else:
+        raise TypeError("email_address must be a str or a (display_name, address) tuple")
     if parsed_address[0] != "":
         display_name = parsed_address[0]
     address = parsed_address[1]
@@ -365,14 +367,18 @@ def parse_email(
     if "to_domains" in parsed_email and "" in parsed_email["to_domains"]:
         parsed_email["to_domains"].remove("")
     if "subject" in parsed_email:
+        # Use a function replacement so backslash sequences in the decoded
+        # subject (e.g. "\1", "\g<0>") aren't interpreted as group references.
         headers_str = re.sub(
-            r"Subject: .+", f"Subject: {parsed_email['subject']}", headers_str
+            r"Subject: .+",
+            lambda _m: f"Subject: {parsed_email['subject']}",
+            headers_str,
         )
 
     if "thread-topic" in parsed_email:
         headers_str = re.sub(
             r"Thread-Topic: .+",
-            f"Thread-Topic: {parsed_email['thread-topic']}",
+            lambda _m: f"Thread-Topic: {parsed_email['thread-topic']}",
             headers_str,
         )
     parsed_email["headers_string"] = headers_str
@@ -455,13 +461,6 @@ def parse_email(
 
     else:
         parsed_email["date"] = None
-    if "reply_to" in parsed_email:
-        parsed_email["reply-to"] = list(
-            map(lambda x: parse_email_address(x), parsed_email["reply_to"])
-        )
-    else:
-        parsed_email["reply-to"] = []
-
     if "attachments" not in parsed_email:
         parsed_email["attachments"] = []
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,6 +93,11 @@ class TestParseEmailAddress:
         result = parse_email_address("garbage <weird@@example.com>")
         assert result["compliant"] is False or result["address"] != ""
 
+    def test_invalid_type_raises_type_error(self):
+        # Neither str nor tuple — must raise a clear TypeError, not UnboundLocalError
+        with pytest.raises(TypeError):
+            parse_email_address(None)  # type: ignore[arg-type]
+
 
 class TestIsOutlookMsg:
     def test_recognises_ole_signature(self):
@@ -197,6 +202,34 @@ class TestParseEmail:
         )
         parsed = parse_email(raw)
         assert parsed["automatic_reply"] is True
+
+    def test_reply_to_preserved(self):
+        raw = (
+            "From: Alice <alice@example.com>\r\n"
+            "Reply-To: Carol <carol@example.com>, dave@example.com\r\n"
+            "To: bob@example.com\r\n"
+            "Subject: Hello\r\n"
+            "\r\n"
+            "body\r\n"
+        )
+        parsed = parse_email(raw)
+        addresses = {addr["address"] for addr in parsed["reply-to"]}
+        assert addresses == {"carol@example.com", "dave@example.com"}
+
+    def test_subject_with_regex_metacharacters(self):
+        # A subject containing backslash sequences must not be treated as a
+        # regex replacement (previously raised re.error / corrupted the value).
+        for subject in (r"Backup \1 done", r"Price \g<0> off", r"100\% \8 \k"):
+            raw = (
+                "From: a@example.com\r\n"
+                "To: b@example.org\r\n"
+                f"Subject: {subject}\r\n"
+                "\r\n"
+                "body\r\n"
+            )
+            parsed = parse_email(raw)
+            assert parsed["subject"] == subject
+            assert f"Subject: {subject}" in parsed["headers_string"]
 
 
 class TestParseAuthenticationResults:


### PR DESCRIPTION
Three reproduced bugs in `mailsuite.utils`:

- **`parse_email()` always returned `reply-to` as `[]`.** The address-headers loop already populates `parsed_email["reply-to"]`, but a later block guarded on the key `"reply_to"` (underscore) — which mailparser never uses (its key is the hyphenated `"reply-to"`) — so the `else` branch unconditionally clobbered the good value with `[]`. Removed the dead/harmful block.
- **`parse_email()` crashed on a `Subject`/`Thread-Topic` with a backslash sequence.** The decoded value was interpolated into the *replacement* arg of `re.sub`, so `\1` / `\g<0>` were treated as group references (`re.error`, or corrupted `headers_string`). Now uses a function replacement so the value is inserted literally.
- **`parse_email_address()` raised `UnboundLocalError`** on input that was neither `str` nor tuple (e.g. `None`); it now raises a clear `TypeError`.

Adds regression tests for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)