### PR TITLE
Fix Gmail since-pagination and stale label cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - Pass `oauth2_token=` (or `oauth2_token_provider=` for a fresh token at send time) with `username=` to authenticate without a password.
   - `oauth2_mechanism=` selects `XOAUTH2` (default) or `OAUTHBEARER`; `oauth2_vendor=` supplies Yahoo's vendor string.
 - Add `ClientAssertion` auth to `MSGraphConnection` for federated / workload-identity scenarios that avoid a long-lived client secret. Pass `client_assertion=` with a signed-JWT assertion, or `client_assertion_provider=` (a zero-arg callable) to supply a fresh assertion each time `azure-identity` acquires a token. The assertion is exchanged for an access token via the JWT-bearer client-credentials grant — it is not itself a Graph access token (#31).
+- Fix two `GmailConnection` bugs:
+  - `fetch_messages(..., since=…)` dropped the date filter on every page after the first, so paginated fetches returned messages older than `since`. The filter is now carried through pagination.
+  - `create_folder()` did not clear the label-id cache, so a label looked up before creation stayed cached as missing — `merge_folders(create=True)` could then move messages to an empty destination label and orphan them. It now clears the cache like `rename_folder` / `delete_folder` / `move_folder`.
 
 ## 2.1.0
 

--- a/mailsuite/mailbox/gmail.py
+++ b/mailsuite/mailbox/gmail.py
@@ -124,6 +124,9 @@ class GmailConnection(MailboxConnection):
                 logger.debug("Folder %s already exists, skipping creation", folder_name)
             else:
                 raise
+        # The label now exists; drop any cached "missing" (empty-id) result so
+        # subsequent lookups resolve it (matches rename/delete/move_folder).
+        self._find_label_id_for_label.cache_clear()
 
     def rename_folder(self, old_name: str, new_name: str) -> None:
         """
@@ -239,7 +242,7 @@ class GmailConnection(MailboxConnection):
 
         if "nextPageToken" in results and self.paginate_messages:
             yield from self._fetch_all_message_ids(
-                reports_label_id, results["nextPageToken"]
+                reports_label_id, results["nextPageToken"], since=since
             )
 
     def fetch_messages(self, reports_folder: str, **kwargs: Any) -> List[str]:

--- a/tests/test_mailbox_gmail.py
+++ b/tests/test_mailbox_gmail.py
@@ -133,6 +133,21 @@ class TestCreateFolder:
         with pytest.raises(HttpError):
             conn.create_folder("Reports")
 
+    def test_create_folder_clears_label_cache(self):
+        # Regression: a prior lookup of a missing label caches "" (lru_cache);
+        # create_folder must clear that cache or later lookups (e.g. during
+        # merge_folders) resolve to "" and orphan messages.
+        conn = _bare_connection()
+        execute = conn.service.labels_obj.list.return_value.execute
+        execute.return_value = {"labels": [{"id": "INBOX", "name": "INBOX"}]}
+        assert conn._find_label_id_for_label("Reports") == ""  # caches the miss
+        conn.service.labels_obj.create.return_value.execute.return_value = {}
+        execute.return_value = {
+            "labels": [{"id": "INBOX", "name": "INBOX"}, {"id": "R1", "name": "Reports"}]
+        }
+        conn.create_folder("Reports")
+        assert conn._find_label_id_for_label("Reports") == "R1"
+
 
 class TestRenameFolder:
     def test_patches_label_name(self):
@@ -258,6 +273,23 @@ class TestFetchMessages:
         # The list call was made with q="after:..."
         kwargs = conn.service.messages_obj.list.call_args.kwargs
         assert kwargs["q"] == "after:2026/04/01"
+
+    def test_since_filter_applied_to_every_page(self):
+        # Regression: the since filter was dropped on every page after the
+        # first, so paginated fetches returned messages older than `since`.
+        conn = _bare_connection()
+        conn._find_label_id_for_label = MagicMock(return_value="L42")
+        conn.service.messages_obj.list.return_value.execute.side_effect = [
+            {"messages": [{"id": "m1"}], "nextPageToken": "tok"},
+            {"messages": [{"id": "m2"}]},
+        ]
+        ids = conn.fetch_messages("Reports", since="2026/04/01")
+        assert ids == ["m1", "m2"]
+        qs = [
+            c.kwargs.get("q")
+            for c in conn.service.messages_obj.list.call_args_list
+        ]
+        assert qs == ["after:2026/04/01", "after:2026/04/01"]
 
 
 class TestFetchMessage:


### PR DESCRIPTION
Two bugs in the Gmail backend:

- **`fetch_messages(..., since=…)` dropped the date filter after page 1.** `_fetch_all_message_ids` recursed for the next page without forwarding `since`, so the `after:` filter applied only to the first page and every subsequent page returned unfiltered (older) messages. Forward `since=` through the recursion.
- **`create_folder()` left a stale label-id cache.** Unlike `rename_folder`/`delete_folder`/`move_folder`, it didn't clear the `lru_cache` on `_find_label_id_for_label`. Since the resolver caches `""` for a missing label, a destination looked up before creation (e.g. by `merge_folders(create=True)` → `folder_exists`) stayed cached as missing, and the subsequent move used an empty destination label id — dropping the source label without adding the destination, orphaning the messages. Now clears the cache after create.

Adds regression tests for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)