### PR TITLE
Fix IMAP folder normalization stripping prefix mid-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - `parse_email_address()` raised `UnboundLocalError` on input that was neither a `str` nor a tuple; it now raises a clear `TypeError`.
 - Fix `mailsuite.smtp.send_email()` not delivering to `Cc` and `Bcc` recipients. The SMTP envelope was built from `message_to` only — Cc/Bcc were appended after the envelope was captured — so the MTA delivered to the `To` addresses alone. The envelope now includes every recipient, and the caller's recipient lists are no longer mutated in place.
 - Fix `from_trusted_domain()` raising `TypeError` when `allow_multiple_authentication_results=True` and the message carries multiple `Authentication-Results` headers (which `parse_email` represents as raw strings). Each header is now parsed before inspection, and the matched DMARC domain is lower-cased/stripped to match the single-header path.
+- Fix `IMAPClient` folder normalization removing the personal-namespace prefix wherever it appeared inside a path rather than only at the start, so e.g. `Projects/INBOX/old` (prefix `INBOX/`) became `INBOX/Projects/old`. Only a leading prefix is now stripped before it is re-applied.
 
 ## 2.1.0
 

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -69,9 +69,11 @@ class IMAPClient(imapclient.IMAPClient):
                 return result.decode("utf-8", "replace")
             return str(result)
 
-        # Strip only a leading namespace prefix before re-adding it below;
-        # an unanchored replace() would also delete the prefix where it appears
-        # inside the path (e.g. "Projects/INBOX/old" -> "Projects/old").
+        # Strip only a leading namespace prefix before re-adding it below. An
+        # unanchored replace() would also delete the prefix where it appears
+        # inside the path, relocating the folder: with prefix "INBOX/",
+        # "Projects/INBOX/old" would normalize to "INBOX/Projects/old" instead
+        # of the correct "INBOX/Projects/INBOX/old".
         if self._path_prefix and folder_name.startswith(self._path_prefix):
             folder_name = folder_name[len(self._path_prefix):]
         if not self._hierarchy_separator == "/":

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -69,7 +69,11 @@ class IMAPClient(imapclient.IMAPClient):
                 return result.decode("utf-8", "replace")
             return str(result)
 
-        folder_name = folder_name.replace(self._path_prefix, "")
+        # Strip only a leading namespace prefix before re-adding it below;
+        # an unanchored replace() would also delete the prefix where it appears
+        # inside the path (e.g. "Projects/INBOX/old" -> "Projects/old").
+        if self._path_prefix and folder_name.startswith(self._path_prefix):
+            folder_name = folder_name[len(self._path_prefix):]
         if not self._hierarchy_separator == "/":
             folder_name = folder_name.replace(self._hierarchy_separator, "")
             folder_name = folder_name.replace("/", self._hierarchy_separator)

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -169,6 +169,42 @@ class TestNormaliseFolder:
         )
         assert client._normalise_folder("Reports") == "INBOX/Reports"
 
+    def test_prefix_inside_path_not_stripped(self, monkeypatch):
+        # The personal-namespace prefix must only be stripped from the start of
+        # the path, not wherever it happens to appear inside it.
+        client = _bare_client(hierarchy_separator="/", path_prefix="INBOX/")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        assert (
+            client._normalise_folder("Projects/INBOX/old")
+            == "INBOX/Projects/INBOX/old"
+        )
+
+    def test_prefix_as_segment_substring_not_stripped(self, monkeypatch):
+        # A prefix that is a substring of a path segment must be left intact.
+        client = _bare_client(hierarchy_separator="/", path_prefix="mail/")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        assert (
+            client._normalise_folder("Work/sendmail/logs")
+            == "mail/Work/sendmail/logs"
+        )
+
+    def test_already_prefixed_path_round_trips(self, monkeypatch):
+        client = _bare_client(hierarchy_separator="/", path_prefix="INBOX/")
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "_normalise_folder",
+            lambda self, name: name,
+        )
+        assert client._normalise_folder("INBOX/Archive/2024") == "INBOX/Archive/2024"
+
 
 class TestFetchMessage:
     def _client(self):


### PR DESCRIPTION
## Bug

`IMAPClient._normalise_folder` removed the personal-namespace prefix with `folder_name.replace(self._path_prefix, "")` before re-applying it. `replace()` is unanchored, so it deleted the prefix **wherever** it appeared in the path, not just at the start:

- `Projects/INBOX/old` (prefix `INBOX/`) → `INBOX/Projects/old` — the folder is relocated.
- `Work/sendmail/logs` (prefix `mail/`) → `mail/Work/sendlogs` — `mail/` inside `send**mail/**` is stripped.

## Fix

Strip only a *leading* prefix (`startswith` + slice) before it's re-applied at the end of the method.

## Tests

Adds `test_prefix_inside_path_not_stripped`, `test_prefix_as_segment_substring_not_stripped`, and `test_already_prefixed_path_round_trips`. Existing normalization tests are unchanged (the bug only manifested when the prefix appeared inside the path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)