### PR TITLE
Fix IMAP move duplicating messages on no-MOVE servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - `parse_email_address()` raised `UnboundLocalError` on input that was neither a `str` nor a tuple; it now raises a clear `TypeError`.
 - Fix `mailsuite.smtp.send_email()` not delivering to `Cc` and `Bcc` recipients. The SMTP envelope was built from `message_to` only — Cc/Bcc were appended after the envelope was captured — so the MTA delivered to the `To` addresses alone. The envelope now includes every recipient, and the caller's recipient lists are no longer mutated in place.
 - Fix `from_trusted_domain()` raising `TypeError` when `allow_multiple_authentication_results=True` and the message carries multiple `Authentication-Results` headers (which `parse_email` represents as raw strings). Each header is now parsed before inspection, and the matched DMARC domain is lower-cased/stripped to match the single-header path.
+- Fix `IMAPClient.move_messages()` duplicating messages on servers without the `MOVE` capability. The copy/delete fallback operated on the full UID list inside the per-100 chunk loop, so moving more than 100 messages copied every message once per chunk. Each chunk is now copied and deleted on its own.
 
 ## 2.1.0
 

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -502,16 +502,16 @@ class IMAPClient(imapclient.IMAPClient):
                             ",".join(str(uid) for uid in chunk), folder_path
                         )
                     )
-                    self.copy(msg_uids, folder_path)
-                    self.delete_messages(msg_uids)
+                    self.copy(chunk, folder_path)
+                    self.delete_messages(chunk)
             else:
                 logger.info(
                     "Moving message UID(s) {0} to {1} by copy".format(
                         ",".join(str(uid) for uid in chunk), folder_path
                     )
                 )
-                self.copy(msg_uids, folder_path)
-                self.delete_messages(msg_uids)
+                self.copy(chunk, folder_path)
+                self.delete_messages(chunk)
 
     def move_messages(
         self, msg_uids: Union[int, List[int]], folder_path: str, _attempt: int = 1

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -362,6 +362,20 @@ class TestMoveMessages:
         # falls back to copy + delete
         client.copy.assert_called_once()
 
+    def test_copy_delete_use_per_chunk_uids(self):
+        # On a no-MOVE server the copy/delete fallback must act on each
+        # 100-UID chunk, not the full list per chunk (which duplicated every
+        # message once per chunk).
+        client = _bare_client(move_supported=False)
+        client.copy = MagicMock()
+        client.delete_messages = MagicMock()
+        uids = list(range(150))
+        client._move_messages(uids, "Archive")
+        copied = [c.args[0] for c in client.copy.call_args_list]
+        deleted = [c.args[0] for c in client.delete_messages.call_args_list]
+        assert copied == [list(range(100)), list(range(100, 150))]
+        assert deleted == [list(range(100)), list(range(100, 150))]
+
 
 class TestExceptions:
     def test_max_retries_is_runtime_error(self):


### PR DESCRIPTION
## Bug

`_move_messages` splits the UIDs into chunks of 100 (`for chunk in _chunks(msg_uids, 100)`), but the copy/delete fallback — used both when `MOVE` raises and when the server lacks the `MOVE` capability — called `self.copy(...)` / `self.delete_messages(...)` with the **full `msg_uids` list** instead of the current `chunk`.

So moving >100 messages to a server without `MOVE` copied **every** message once per chunk (250 messages → each copied across all three iterations, with repeated copy/delete of already-expunged UIDs). The chunking was entirely defeated.

## Fix

Use `chunk` in both fallback branches.

## Tests

Adds `test_copy_delete_use_per_chunk_uids`: a no-MOVE client moving 150 UIDs must copy/delete `[0:100]` then `[100:150]` — one call per chunk — not the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)