### PR TITLE
Fix IMAP IDLE missing new mail signalled only by EXISTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix `from_trusted_domain()` raising `TypeError` when `allow_multiple_authentication_results=True` and the message carries multiple `Authentication-Results` headers (which `parse_email` represents as raw strings). Each header is now parsed before inspection, and the matched DMARC domain is lower-cased/stripped to match the single-header path.
 - Fix `IMAPClient` folder normalization removing the personal-namespace prefix wherever it appeared inside a path rather than only at the start, so e.g. `Projects/INBOX/old` (prefix `INBOX/`) became `INBOX/Projects/old`. Only a leading prefix is now stripped before it is re-applied.
 - Fix `IMAPClient.move_messages()` duplicating messages on servers without the `MOVE` capability. The copy/delete fallback operated on the full UID list inside the per-100 chunk loop, so moving more than 100 messages copied every message once per chunk. Each chunk is now copied and deleted on its own.
+- Fix the IMAP IDLE watch loop ignoring new mail on servers that signal it with an untagged `EXISTS` but no `RECENT`. The loop reacted only to `RECENT`; it now also reacts to `EXISTS` (the standard new-message signal).
 
 ## 2.1.0
 

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -119,7 +119,12 @@ class IMAPClient(imapclient.IMAPClient):
                         self.idle()
                     else:
                         for r in responses:
-                            if r[0] != 0 and r[1] == b"RECENT":
+                            # New mail is signalled by an untagged EXISTS (the
+                            # new message count); RECENT is optional and many
+                            # servers never send it, so react to either.
+                            if r[1] == b"EXISTS" or (
+                                r[1] == b"RECENT" and r[0] != 0
+                            ):
                                 self.idle_done()
                                 idle_callback(self)
                                 idle_start_time = time.monotonic()

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -206,6 +206,47 @@ class TestNormaliseFolder:
         assert client._normalise_folder("INBOX/Archive/2024") == "INBOX/Archive/2024"
 
 
+class TestStartIdle:
+    def _idle_client(self):
+        client = _bare_client()
+        client._idle_supported = True
+        client.idle = MagicMock()
+        client.idle_done = MagicMock()
+        return client
+
+    def test_fires_callback_on_exists(self):
+        # An untagged EXISTS must trigger the callback (RECENT is optional and
+        # many servers never send it).
+        client = self._idle_client()
+        client.idle_check = MagicMock(
+            side_effect=[[(1, b"EXISTS")], KeyboardInterrupt()]
+        )
+        calls = []
+        client._start_idle(lambda c: calls.append(c), idle_timeout=1)
+        # one call at startup + one for the EXISTS response
+        assert len(calls) == 2
+
+    def test_fires_callback_on_recent(self):
+        client = self._idle_client()
+        client.idle_check = MagicMock(
+            side_effect=[[(1, b"RECENT")], KeyboardInterrupt()]
+        )
+        calls = []
+        client._start_idle(lambda c: calls.append(c), idle_timeout=1)
+        assert len(calls) == 2
+
+    def test_ignores_keepalive_responses(self):
+        # A non-mail response (e.g. "still here") must not fire the callback.
+        client = self._idle_client()
+        client.idle_check = MagicMock(
+            side_effect=[[(b"OK", b"Still here")], KeyboardInterrupt()]
+        )
+        calls = []
+        client._start_idle(lambda c: calls.append(c), idle_timeout=1)
+        # only the startup call
+        assert len(calls) == 1
+
+
 class TestFetchMessage:
     def _client(self):
         client = _bare_client()


### PR DESCRIPTION
## Bug

The IMAP IDLE watch loop fired `idle_callback` only on an untagged `RECENT` response:

```python
if r[0] != 0 and r[1] == b"RECENT":
```

But new mail is signalled by an untagged **`EXISTS`** (the new message count) — `RECENT` is optional and many servers never send it (imapclient's own `idle_check` docstring shows new mail as `(1, b'EXISTS')`). A mailbox that announced new mail with `EXISTS` alone was never reported to the callback.

## Fix

React to `EXISTS` as well as a non-zero `RECENT`:

```python
if r[1] == b"EXISTS" or (r[1] == b"RECENT" and r[0] != 0):
```

## Tests

Adds `TestStartIdle` driving the loop with a mocked `idle_check`: fires on `EXISTS`, fires on `RECENT`, and does **not** fire on a keepalive (`OK Still here`) response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)