### PR TITLE
Fix delete_messages raising on servers without UIDPLUS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix `from_trusted_domain()` raising `TypeError` when `allow_multiple_authentication_results=True` and the message carries multiple `Authentication-Results` headers (which `parse_email` represents as raw strings). Each header is now parsed before inspection, and the matched DMARC domain is lower-cased/stripped to match the single-header path.
 - Fix `IMAPClient` folder normalization removing the personal-namespace prefix wherever it appeared inside a path rather than only at the start, so e.g. `Projects/INBOX/old` (prefix `INBOX/`) became `INBOX/Projects/old`. Only a leading prefix is now stripped before it is re-applied.
 - Fix `IMAPClient.move_messages()` duplicating messages on servers without the `MOVE` capability. The copy/delete fallback operated on the full UID list inside the per-100 chunk loop, so moving more than 100 messages copied every message once per chunk. Each chunk is now copied and deleted on its own.
+- Fix `IMAPClient.delete_messages()` raising on servers without the `UIDPLUS` capability. It always issued a `UID EXPUNGE` (expunge of specific UIDs), which requires UIDPLUS; on servers lacking it the error was uncaught. It now falls back to a plain `EXPUNGE` when UIDPLUS is unavailable.
 
 ## 2.1.0
 

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -441,7 +441,13 @@ class IMAPClient(imapclient.IMAPClient):
         )
         try:
             imapclient.IMAPClient.delete_messages(self, messages, silent=silent)
-            imapclient.IMAPClient.expunge(self, messages)
+            # Expunging specific UIDs (UID EXPUNGE) requires the UIDPLUS
+            # capability; on servers without it, fall back to a plain EXPUNGE,
+            # which removes all messages flagged \\Deleted in the folder.
+            if self.has_capability("UIDPLUS"):
+                imapclient.IMAPClient.expunge(self, messages)
+            else:
+                imapclient.IMAPClient.expunge(self)
         except (socket.timeout, imaplib.IMAP4.abort):
             _attempt = _attempt + 1
             if _attempt > self.max_retries:

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -275,6 +275,7 @@ class TestDeleteMessages:
     def _client(self):
         client = _bare_client()
         client.reset_connection = MagicMock()
+        client.has_capability = MagicMock(return_value=True)
         return client
 
     def test_int_coerced_to_list(self, monkeypatch):
@@ -319,6 +320,38 @@ class TestDeleteMessages:
         client.max_retries = 2
         with pytest.raises(MaxRetriesExceeded):
             client.delete_messages([1])
+
+    def test_uid_expunge_when_uidplus(self, monkeypatch):
+        # With UIDPLUS, expunge only the given UIDs (UID EXPUNGE).
+        expunged = {}
+        monkeypatch.setattr(
+            imapclient.IMAPClient, "delete_messages", lambda *a, **k: None
+        )
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "expunge",
+            lambda self, *a: expunged.setdefault("args", a),
+        )
+        client = self._client()  # has_capability -> True
+        client.delete_messages([1, 2])
+        assert expunged["args"] == ([1, 2],)
+
+    def test_plain_expunge_without_uidplus(self, monkeypatch):
+        # Without UIDPLUS, UID EXPUNGE isn't supported; fall back to plain
+        # EXPUNGE (no UIDs) rather than raising an IMAPClientError.
+        expunged = {}
+        monkeypatch.setattr(
+            imapclient.IMAPClient, "delete_messages", lambda *a, **k: None
+        )
+        monkeypatch.setattr(
+            imapclient.IMAPClient,
+            "expunge",
+            lambda self, *a: expunged.setdefault("args", a),
+        )
+        client = self._client()
+        client.has_capability = MagicMock(return_value=False)
+        client.delete_messages([1, 2])
+        assert expunged["args"] == ()
 
 
 class TestCreateFolder:
@@ -366,6 +399,7 @@ class TestMoveMessages:
         client.reset_connection = MagicMock()
         client.move = MagicMock()
         client.copy = MagicMock()
+        client.has_capability = MagicMock(return_value=True)
         return client
 
     def test_move_when_supported(self, monkeypatch):


### PR DESCRIPTION
## Bug

`delete_messages` flags the messages `\Deleted` and then calls `expunge(messages)`. Passing UIDs makes imapclient issue a **`UID EXPUNGE`**, which requires the **UIDPLUS** extension (imapclient's own `uid_expunge` is even decorated `@require_capability("UIDPLUS")`). On a server without UIDPLUS the server rejects it with a `BAD`/`NO` (`IMAPClientError`), and `delete_messages` only catches `socket.timeout` / `IMAP4.abort` — so the delete raised.

## Fix

Guard with `has_capability("UIDPLUS")`: issue `UID EXPUNGE` when it's supported, otherwise fall back to a plain `EXPUNGE` (which removes all `\Deleted` messages in the selected folder).

## Tests

Adds `test_uid_expunge_when_uidplus` and `test_plain_expunge_without_uidplus`. The delete/move test helpers now mock `has_capability` (the move copy/delete fallback runs through `delete_messages`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)