### PR TITLE
Fix create_email() emitting an empty Cc header for message_cc=[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix `IMAPClient.move_messages()` duplicating messages on servers without the `MOVE` capability. The copy/delete fallback operated on the full UID list inside the per-100 chunk loop, so moving more than 100 messages copied every message once per chunk. Each chunk is now copied and deleted on its own.
 - Fix `IMAPClient.delete_messages()` raising on servers without the `UIDPLUS` capability. It always issued a `UID EXPUNGE` (expunge of specific UIDs), which requires UIDPLUS; on servers lacking it the error was uncaught. It now falls back to a plain `EXPUNGE` when UIDPLUS is unavailable.
 - Fix the IMAP IDLE watch loop ignoring new mail on servers that signal it with an untagged `EXISTS` but no `RECENT`. The loop reacted only to `RECENT`; it now also reacts to `EXISTS` (the standard new-message signal).
+- Fix `create_email()` emitting an empty `Cc:` header when `message_cc=[]`. It now adds the header only when there are Cc addresses, matching the `To` handling.
 
 ## 2.1.0
 

--- a/mailsuite/utils.py
+++ b/mailsuite/utils.py
@@ -741,7 +741,7 @@ def create_email(
     msg["From"] = message_from
     if message_to:
         msg["To"] = ", ".join(message_to)
-    if message_cc is not None:
+    if message_cc:
         msg["Cc"] = ", ".join(message_cc)
     msg["Date"] = email.utils.formatdate(localtime=True)
     if subject:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -138,6 +138,15 @@ class TestCreateEmail:
         )
         assert "Cc: c@example.org, d@example.org" in msg
 
+    def test_empty_cc_list_omits_header(self):
+        # An empty Cc list must not emit a bare "Cc:" header (matches To).
+        msg = create_email(
+            message_from="a@example.com",
+            message_to=["b@example.org"],
+            message_cc=[],
+        )
+        assert "Cc:" not in msg
+
     def test_custom_headers(self):
         msg = create_email(
             message_from="a@example.com",


### PR DESCRIPTION
`create_email` added the `To` header with a truthiness check (`if message_to:`), so an empty list adds no header — but `Cc` used `if message_cc is not None:`, so `message_cc=[]` produced a bare `Cc:` (empty value) header. Use the same truthiness check as `To`.

Adds `test_empty_cc_list_omits_header`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)