### PR TITLE
Fix IMAP IDLE watch loop nesting a new loop on every reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix `IMAPClient.move_messages()` duplicating messages on servers without the `MOVE` capability. The copy/delete fallback operated on the full UID list inside the per-100 chunk loop, so moving more than 100 messages copied every message once per chunk. Each chunk is now copied and deleted on its own.
 - Fix `IMAPClient.delete_messages()` raising on servers without the `UIDPLUS` capability. It always issued a `UID EXPUNGE` (expunge of specific UIDs), which requires UIDPLUS; on servers lacking it the error was uncaught. It now falls back to a plain `EXPUNGE` when UIDPLUS is unavailable.
 - Fix the IMAP IDLE watch loop ignoring new mail on servers that signal it with an untagged `EXISTS` but no `RECENT`. The loop reacted only to `RECENT`; it now also reacts to `EXISTS` (the standard new-message signal).
+- Fix the IMAP IDLE watch loop stacking a nested IDLE loop on every reconnect. A connection drop during `watch()` called `reset_connection()`, which re-ran `__init__` and restarted IDLE recursively (duplicated callbacks, ever-deepening recursion on a long-running watch). Reconnects now re-arm the existing loop in place via a re-entrancy guard.
 
 ## 2.1.0
 

--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -101,6 +101,9 @@ class IMAPClient(imapclient.IMAPClient):
         idle_callback(self)
         idle_start_time = time.monotonic()
         self.idle()
+        # Mark the loop active so a reconnect (reset_connection -> __init__)
+        # re-arms this loop in place instead of starting a nested IDLE loop.
+        self._idle_running = True
         while True:
             try:
                 # Refresh the IDLE session every 5 minutes to stay connected
@@ -133,13 +136,20 @@ class IMAPClient(imapclient.IMAPClient):
             except (KeyError, socket.error, BrokenPipeError, ConnectionResetError):
                 logger.debug("IMAP error: Connection reset")
                 self.reset_connection()
+                idle_callback(self)
+                idle_start_time = time.monotonic()
+                self.idle()
             except imapclient.exceptions.IMAPClientError as error:
                 error = error.__str__().lstrip("b'").rstrip("'").rstrip(".")
                 # Workaround for random Exchange/Microsoft 365 IMAP errors
                 if "unexpected response" in error or "BAD" in error:
                     self.reset_connection()
+                    idle_callback(self)
+                    idle_start_time = time.monotonic()
+                    self.idle()
             except KeyboardInterrupt:
                 break
+        self._idle_running = False
         try:
             self.idle_done()
         except BrokenPipeError:
@@ -315,7 +325,10 @@ class IMAPClient(imapclient.IMAPClient):
         ) as error:
             error = error.__str__().lstrip("b'").rstrip("'").rstrip(".")
             raise imapclient.exceptions.IMAPClientError(error)
-        if idle_callback is not None:
+        # Skip starting IDLE if a loop is already running on this connection:
+        # reset_connection() re-runs __init__ from inside the loop, and a
+        # nested _start_idle would stack IDLE loops on every reconnect.
+        if idle_callback is not None and not getattr(self, "_idle_running", False):
             self._start_idle(idle_callback, idle_timeout=idle_timeout)
 
     def reset_connection(self):

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -246,6 +246,24 @@ class TestStartIdle:
         # only the startup call
         assert len(calls) == 1
 
+    def test_reconnects_and_rearms_on_connection_error(self):
+        # A dropped connection mid-IDLE must reconnect and re-arm the *same*
+        # loop in place (re-issue idle()), rather than crash or leave it
+        # un-idled. (The reconnect also sets _idle_running so __init__ won't
+        # start a nested loop — see the integration test for that path.)
+        client = self._idle_client()
+        client.reset_connection = MagicMock()
+        client.idle_check = MagicMock(
+            side_effect=[socket.error("dropped"), KeyboardInterrupt()]
+        )
+        calls = []
+        client._start_idle(lambda c: calls.append(c), idle_timeout=1)
+        client.reset_connection.assert_called_once()
+        # idle() re-armed after reconnecting: once at startup + once after
+        assert client.idle.call_count == 2
+        # callback fired again after reconnecting (re-check for missed mail)
+        assert len(calls) == 2
+
 
 class TestFetchMessage:
     def _client(self):

--- a/tests/test_imap_idle_integration.py
+++ b/tests/test_imap_idle_integration.py
@@ -1,0 +1,243 @@
+"""Docker-based integration tests for the IMAP IDLE watch loop.
+
+These exercise ``mailsuite.imap.IMAPClient``'s IDLE watch against a real IMAP
+server (GreenMail) running in Docker — the behaviour that the mocked unit
+tests can't cover: live IDLE notifications and reconnect-during-IDLE.
+
+They are **opt-in**: skipped unless Docker is available *and*
+``MAILSUITE_DOCKER_TESTS=1`` is set, so the normal suite (and CI, which has no
+Docker) doesn't pull/start a container. Run them with::
+
+    MAILSUITE_DOCKER_TESTS=1 pytest tests/test_imap_idle_integration.py
+"""
+
+from __future__ import annotations
+
+import os
+import smtplib
+import socket
+import subprocess
+import threading
+import time
+import uuid
+from email.message import EmailMessage
+
+import imapclient
+import pytest
+
+from mailsuite.imap import IMAPClient
+
+IMAGE = "greenmail/standalone:2.1.4"
+USER = "test@localhost"
+PASSWORD = "pass"
+
+
+def _docker_available() -> bool:
+    if not os.environ.get("MAILSUITE_DOCKER_TESTS"):
+        return False
+    try:
+        subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+            timeout=15,
+        )
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _docker_available(),
+    reason="requires Docker and MAILSUITE_DOCKER_TESTS=1",
+)
+
+
+def _host_port(name: str, container_port: str) -> int:
+    """Return the host port Docker mapped to ``container_port`` for ``name``."""
+    out = subprocess.run(
+        ["docker", "port", name, container_port],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip().splitlines()[0]
+    return int(out.rsplit(":", 1)[1])
+
+
+@pytest.fixture(scope="module")
+def greenmail():
+    """Start a GreenMail container; yield (host, imap_port, smtp_port)."""
+    name = f"ms-idle-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        [
+            "docker", "run", "-d", "--name", name,
+            # Let Docker assign free host ports (avoids a pick-then-bind race).
+            "-p", "3143", "-p", "3025",
+            # Bind 0.0.0.0 inside the container so the port-forward reaches it
+            # (GreenMail otherwise binds 127.0.0.1).
+            "-e", "GREENMAIL_OPTS=-Dgreenmail.setup.test.all "
+                  "-Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled",
+            IMAGE,
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 30
+        while True:
+            try:
+                imap_port = _host_port(name, "3143")
+                smtp_port = _host_port(name, "3025")
+                break
+            except Exception:
+                if time.monotonic() > deadline:
+                    raise
+                time.sleep(0.5)
+        deadline = time.monotonic() + 60
+        while True:
+            try:
+                c = imapclient.IMAPClient("127.0.0.1", port=imap_port, ssl=False)
+                c.login(USER, PASSWORD)
+                c.logout()
+                break
+            except Exception:
+                if time.monotonic() > deadline:
+                    logs = subprocess.run(
+                        ["docker", "logs", name],
+                        capture_output=True, text=True,
+                    ).stderr
+                    raise RuntimeError(f"GreenMail not ready:\n{logs[-2000:]}")
+                time.sleep(1)
+        yield "127.0.0.1", imap_port, smtp_port
+    finally:
+        subprocess.run(["docker", "rm", "-f", name], stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL)
+
+
+def _deliver(smtp_port: int, subject: str) -> None:
+    msg = EmailMessage()
+    msg["From"] = "sender@example.com"
+    msg["To"] = USER
+    msg["Subject"] = subject
+    msg.set_content("body")
+    with smtplib.SMTP("127.0.0.1", smtp_port) as s:
+        s.send_message(msg)
+
+
+def _clear_mailbox(imap_port: int) -> None:
+    """Empty INBOX so tests start from a known count (the fixture is shared)."""
+    c = imapclient.IMAPClient("127.0.0.1", port=imap_port, ssl=False)
+    try:
+        c.login(USER, PASSWORD)
+        c.select_folder("INBOX")
+        uids = c.search(["ALL"])
+        if uids:
+            c.delete_messages(uids)
+            c.expunge()
+    finally:
+        c.logout()
+
+
+def _wait_until(predicate, timeout=20.0, interval=0.25) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+def _start_watch(host, port, observations, stash, stop_at, errors=None):
+    """Run an IDLE watch in a thread; the callback records the INBOX message
+    count and stops the watch once it reaches ``stop_at``."""
+    def cb(client):
+        stash["client"] = client
+        n = None
+        for _ in range(5):  # tolerate transient search races around IDLE
+            try:
+                n = len(client.search(["ALL"]))
+                break
+            except Exception:
+                time.sleep(0.2)
+        if n is None:
+            return
+        observations.append(n)
+        if n >= stop_at:
+            raise KeyboardInterrupt  # cleanly breaks the IDLE loop
+
+    def run():
+        try:
+            IMAPClient(
+                host=host, port=port, ssl=False,
+                username=USER, password=PASSWORD,
+                idle_callback=cb, idle_timeout=2, max_retries=5,
+            )
+        except KeyboardInterrupt:
+            pass
+        except BaseException as exc:  # surface real failures via `errors`
+            if errors is not None:
+                errors.append(repr(exc))
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    return t
+
+
+def test_idle_detects_new_mail(greenmail):
+    host, imap_port, smtp_port = greenmail
+    _clear_mailbox(imap_port)
+    observations, stash = [], {}
+    t = _start_watch(host, imap_port, observations, stash, stop_at=1)
+    assert _wait_until(lambda: "client" in stash), "watch never connected"
+    _deliver(smtp_port, "hello")
+    assert _wait_until(lambda: any(n >= 1 for n in observations)), (
+        f"new mail not detected over IDLE; observations={observations}"
+    )
+    t.join(timeout=5)
+
+
+def test_reconnect_during_idle_recovers_without_recursion(greenmail, monkeypatch):
+    host, imap_port, smtp_port = greenmail
+    _clear_mailbox(imap_port)
+    observations, stash, errors = [], {}, []
+
+    # Count entries into _start_idle and reconnects: a reconnect must re-arm the
+    # existing loop, not start a nested one (the pre-fix bug entered _start_idle
+    # again on every reconnect).
+    entries, resets = [], []
+    original_idle = IMAPClient._start_idle
+    original_reset = IMAPClient.reset_connection
+
+    def counting(self, idle_callback, idle_timeout=30):
+        entries.append(1)
+        return original_idle(self, idle_callback, idle_timeout=idle_timeout)
+
+    def reset_spy(self):
+        resets.append(1)
+        return original_reset(self)
+
+    monkeypatch.setattr(IMAPClient, "_start_idle", counting)
+    monkeypatch.setattr(IMAPClient, "reset_connection", reset_spy)
+
+    # Start the watch on an empty mailbox; it stops once it sees one message,
+    # which is delivered only AFTER the reconnect — so detecting it proves the
+    # loop re-armed on the reconnected connection.
+    t = _start_watch(host, imap_port, observations, stash, stop_at=1, errors=errors)
+    assert _wait_until(lambda: "client" in stash), "watch never connected"
+    time.sleep(2)  # let the IDLE session settle before dropping it
+
+    # Force a connection drop mid-IDLE to trigger reset_connection.
+    stash["client"].socket().shutdown(socket.SHUT_RDWR)
+    assert _wait_until(lambda: len(resets) >= 1, timeout=30), (
+        "drop did not trigger a reconnect"
+    )
+
+    _deliver(smtp_port, "after-reconnect")
+    assert _wait_until(
+        lambda: any(n >= 1 for n in observations), timeout=30
+    ), f"message after reconnect not detected; observations={observations}, errors={errors}"
+
+    t.join(timeout=5)
+    assert not t.is_alive(), "watch thread did not stop"
+    assert errors == [], f"watch raised during reconnect: {errors}"
+    # The reconnect re-armed the existing loop rather than nesting a new one.
+    assert len(entries) == 1, f"_start_idle re-entered (recursion): {len(entries)}x"


### PR DESCRIPTION
## Bug

`reset_connection()` re-runs `__init__`, which — when `idle_callback` is set — started IDLE again. Called from *inside* the IDLE loop on a connection drop, that spawned a **nested** `_start_idle`: every reconnect stacked another loop, duplicating `idle_callback` invocations and deepening recursion over a long-running `watch()` (eventual `RecursionError` on a flapping connection).

## Fix

- Guard `__init__` with a `_idle_running` flag so it won't start a nested loop while one is active.
- Have the loop re-arm itself after `reset_connection()` (re-issue `idle()` and re-check for mail), so a reconnect continues the existing loop in place.

## Tests

- **Deterministic unit test** (mocked): a connection error mid-IDLE reconnects and re-arms the loop exactly once, in place. Runs in CI.
- **Opt-in Docker integration test** (`tests/test_imap_idle_integration.py`, gated on `MAILSUITE_DOCKER_TESTS=1` + Docker): runs the watch against a real GreenMail server, validates IDLE new-mail detection (which also exercises the `EXISTS`-only path), and forces a mid-IDLE socket drop to confirm the watch recovers and that `_start_idle` is entered only once (no recursion). It skips cleanly without the flag (so CI/normal `pytest` are unaffected — 345 passed, 2 skipped).

I validated the reconnect path manually against GreenMail: the watch recovered, `_start_idle` was entered once (no recursion), and no errors were raised. **Note:** the threaded reconnect integration test is timing-sensitive and may need a re-run; the unit test is the reliable coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)