### PR TITLE
Fix Graph fetch_messages ignoring batch_size when since is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix `IMAPClient.move_messages()` duplicating messages on servers without the `MOVE` capability. The copy/delete fallback operated on the full UID list inside the per-100 chunk loop, so moving more than 100 messages copied every message once per chunk. Each chunk is now copied and deleted on its own.
 - Fix `IMAPClient.delete_messages()` raising on servers without the `UIDPLUS` capability. It always issued a `UID EXPUNGE` (expunge of specific UIDs), which requires UIDPLUS; on servers lacking it the error was uncaught. It now falls back to a plain `EXPUNGE` when UIDPLUS is unavailable.
 - Fix the IMAP IDLE watch loop ignoring new mail on servers that signal it with an untagged `EXISTS` but no `RECENT`. The loop reacted only to `RECENT`; it now also reacts to `EXISTS` (the standard new-message signal).
+- Fix `MSGraphConnection.fetch_messages()` ignoring `batch_size` whenever `since` was set, so a date-filtered fetch pulled every matching page regardless of the requested cap. `batch_size` and `since` are independent now — the caller controls both.
 
 ## 2.1.0
 

--- a/mailsuite/mailbox/graph.py
+++ b/mailsuite/mailbox/graph.py
@@ -493,7 +493,7 @@ class MSGraphConnection(MailboxConnection):
         while page is not None and page.value:
             ids.extend(m.id for m in page.value if m.id)
             next_link = page.odata_next_link
-            keep_going = since is not None or batch_size == 0 or len(ids) < batch_size
+            keep_going = batch_size == 0 or len(ids) < batch_size
             if not next_link or not keep_going:
                 break
             page = (

--- a/tests/test_mailbox_graph.py
+++ b/tests/test_mailbox_graph.py
@@ -615,6 +615,46 @@ class TestFetchMessagesPagination:
         ids = conn.fetch_messages("Reports")
         assert ids == ["m1", "m2"]
 
+    def test_batch_size_caps_even_with_since(self):
+        # Regression: `since` used to disable the batch_size cap entirely, so a
+        # filtered fetch pulled every page. The caller should control both
+        # independently — batch_size must still cap when `since` is set.
+        conn = _make_conn()
+        conn._client.users.by_user_id("x").mail_folders._listing_pages = [
+            MagicMock(value=[MagicMock(id="f1", display_name="Reports")]),
+        ]
+        item = conn._client.users.by_user_id("x").mail_folders.by_mail_folder_id("f1")
+        item.messages.next_pages = [
+            MagicMock(value=[MagicMock(id="m1"), MagicMock(id="m2")],
+                      odata_next_link="L2"),
+            MagicMock(value=[MagicMock(id="m3"), MagicMock(id="m4")],
+                      odata_next_link=None),
+        ]
+        ids = conn.fetch_messages(
+            "Reports", batch_size=2, since="2024-01-01T00:00:00Z"
+        )
+        assert ids == ["m1", "m2"]  # stopped after the cap, didn't fetch page 2
+        # the since filter was still applied to the query
+        cfg = item.messages.get_calls[0]
+        assert cfg.query_parameters.filter == "receivedDateTime ge 2024-01-01T00:00:00Z"
+
+    def test_batch_size_zero_fetches_all_with_since(self):
+        # batch_size=0 means "no cap"; combined with `since` it fetches every
+        # matching page.
+        conn = _make_conn()
+        conn._client.users.by_user_id("x").mail_folders._listing_pages = [
+            MagicMock(value=[MagicMock(id="f1", display_name="Reports")]),
+        ]
+        item = conn._client.users.by_user_id("x").mail_folders.by_mail_folder_id("f1")
+        item.messages.next_pages = [
+            MagicMock(value=[MagicMock(id="m1"), MagicMock(id="m2")],
+                      odata_next_link="L2"),
+            MagicMock(value=[MagicMock(id="m3"), MagicMock(id="m4")],
+                      odata_next_link=None),
+        ]
+        ids = conn.fetch_messages("Reports", batch_size=0, since="2024-01-01T00:00:00Z")
+        assert ids == ["m1", "m2", "m3", "m4"]
+
 
 class TestWatch:
     def test_exits_on_config_reload(self):


### PR DESCRIPTION
## Bug

`MSGraphConnection._fetch_messages_async` stopped paginating only when `since is None`:

```python
keep_going = since is not None or batch_size == 0 or len(ids) < batch_size
```

So whenever a caller passed `since`, the `batch_size` cap was ignored and the fetch pulled **every** matching page. This isn't a Graph limitation — `$top` (page size) and `$filter` compose fine and `@odata.nextLink` carries the filter across pages ([list messages docs](https://learn.microsoft.com/en-us/graph/api/user-list-messages)), so the caller should be free to combine a date filter with a count cap.

## Fix

```python
keep_going = batch_size == 0 or len(ids) < batch_size
```

`batch_size` now caps regardless of `since`; `since` only controls the `$filter`. The two are independent.

## Tests

- `batch_size` caps a `since`-filtered fetch (stops after the cap, doesn't fetch further pages) and the `since` filter is still applied to the query.
- `batch_size=0` (no cap) with `since` fetches all matching pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)