### PR TITLE
Require mail-parser>=4.2.1 (release 2.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.1
+
+- Require `mail-parser>=4.2.1` (was `>=4.1.2`). 4.2.1 stops returning a phantom `('', '')` entry for absent address headers and adds the CVE-2023-27043 strict address-parsing hardening. `parse_email()` already re-parsed these headers itself, so mailsuite's own output is unchanged — this guarantees the fixed dependency for code that reads the underlying mail-parser object.
+
 ## 2.2.0
 
 ### Enhancements

--- a/mailsuite/__init__.py
+++ b/mailsuite/__init__.py
@@ -1,3 +1,3 @@
 """A Python package to simplify receiving, parsing, and sending email"""
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "expiringdict==1.2.2",
     "html2text>=2020.1.16",
     "IMAPClient>=3.1.0",
-    "mail-parser>=4.1.2",
+    "mail-parser>=4.2.1",
     "publicsuffix2>=2.20190812",
 ]
 dynamic = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mail-parser>=4.1.2
+mail-parser>=4.2.1
 imapclient>=3.1.0
 html2text>=2020.1.16
 dnspython>=2.0.0


### PR DESCRIPTION
## Summary

Raise the `mail-parser` floor from `>=4.1.2` to `>=4.2.1` and cut a patch release (2.2.1).

mail-parser 4.1.x returned a phantom `('', '')` address tuple for **absent** address headers (`to`/`cc`/`bcc`/`from`/`reply-to`/`delivered-to`). 4.2.1 fixed that (it filters empty-address entries after parsing) and added the CVE-2023-27043 strict address-parsing hardening with a forensic regex fallback.

mailsuite's own `parse_email()` was **not** affected by the upstream bug — it re-parses these headers itself ([`mailsuite/utils.py`](https://github.com/seanthegeek/mailsuite/blob/fix/mail-parser-4.2.1-floor/mailsuite/utils.py)) and already returns `[]`/`None` for absent headers regardless of mail-parser version (verified empirically). The floor bump guarantees the fixed dependency for downstream code that reads the underlying mail-parser object directly, so this PR does not change mailsuite's own observable behavior.

## Changes

- `pyproject.toml` / `requirements.txt`: `mail-parser>=4.1.2` → `>=4.2.1` (4.2.1 is the current latest release).
- `mailsuite/__init__.py`: `__version__` 2.2.0 → 2.2.1.
- `CHANGELOG.md`: new `## 2.2.1` section.

## Testing

No code changed; existing test suite already runs against the installed mail-parser 4.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)