### PR TITLE
feat(imap): honor config_reloading in the IDLE loop

### DIFF
--- a/mailsuite/imap.py
+++ b/mailsuite/imap.py
@@ -96,13 +96,17 @@ class IMAPClient(imapclient.IMAPClient):
             return result.decode("utf-8", "replace")
         return str(result)
 
-    def _start_idle(self, idle_callback, idle_timeout: int = 30):
+    def _start_idle(self, idle_callback, idle_timeout: int = 30, config_reloading=None):
         """
         Starts an IMAP IDLE session
 
         Args:
             idle_callback: A callback function
             idle_timeout: Number of seconds to wait for an IDLE response
+            config_reloading: Optional zero-arg callable; when it returns a
+                truthy value the IDLE loop exits cleanly so the caller can
+                reload config or shut down. Checked at the top of each cycle,
+                while IDLE is active, so idle_done() stays valid.
         """
         if self._idle_supported is False:
             raise imapclient.exceptions.IMAPClientError(
@@ -115,6 +119,8 @@ class IMAPClient(imapclient.IMAPClient):
         # re-arms this loop in place instead of starting a nested IDLE loop.
         self._idle_running = True
         while True:
+            if config_reloading and config_reloading():
+                break
             try:
                 # Refresh the IDLE session every 5 minutes to stay connected
                 if time.monotonic() - idle_start_time > 5 * 60:
@@ -183,6 +189,7 @@ class IMAPClient(imapclient.IMAPClient):
         oauth2_token_provider: Optional[Callable[[], str]] = None,
         oauth2_mechanism: str = "XOAUTH2",
         oauth2_vendor: Optional[str] = None,
+        config_reloading: Optional[Callable[[], bool]] = None,
     ):
         """
         Connects to an IMAP server
@@ -339,7 +346,11 @@ class IMAPClient(imapclient.IMAPClient):
         # reset_connection() re-runs __init__ from inside the loop, and a
         # nested _start_idle would stack IDLE loops on every reconnect.
         if idle_callback is not None and not getattr(self, "_idle_running", False):
-            self._start_idle(idle_callback, idle_timeout=idle_timeout)
+            self._start_idle(
+                idle_callback,
+                idle_timeout=idle_timeout,
+                config_reloading=config_reloading,
+            )
 
     def reset_connection(self):
         """Resets the connection to the IMAP server"""

--- a/mailsuite/mailbox/imap.py
+++ b/mailsuite/mailbox/imap.py
@@ -174,6 +174,7 @@ class IMAPConnection(MailboxConnection):
                     oauth2_token_provider=self._oauth2_token_provider,
                     oauth2_mechanism=self._oauth2_mechanism,
                     oauth2_vendor=self._oauth2_vendor,
+                    config_reloading=config_reloading,
                 )
             except (timeout, IMAPClientError):
                 logger.warning("IMAP connection timeout. Reconnecting...")

--- a/tests/test_imap.py
+++ b/tests/test_imap.py
@@ -264,6 +264,47 @@ class TestStartIdle:
         # callback fired again after reconnecting (re-check for missed mail)
         assert len(calls) == 2
 
+    def test_config_reloading_truthy_exits_cleanly(self):
+        # A truthy config_reloading at the top of a cycle breaks the loop
+        # cleanly: idle_check is never consulted and the trailing idle_done()
+        # still runs (it was checked while IDLE was active).
+        client = self._idle_client()
+        client.idle_check = MagicMock()
+        calls = []
+        client._start_idle(
+            lambda c: calls.append(c),
+            idle_timeout=1,
+            config_reloading=lambda: True,
+        )
+        # only the startup call — the loop broke before any idle_check
+        assert len(calls) == 1
+        client.idle_check.assert_not_called()
+        client.idle_done.assert_called_once()
+        assert client._idle_running is False
+
+    def test_config_reloading_falsy_keeps_watching(self):
+        # A falsy config_reloading must not disturb normal IDLE processing.
+        client = self._idle_client()
+        client.idle_check = MagicMock(
+            side_effect=[[(1, b"EXISTS")], KeyboardInterrupt()]
+        )
+        reload_calls = []
+
+        def config_reloading():
+            reload_calls.append(1)
+            return False
+
+        calls = []
+        client._start_idle(
+            lambda c: calls.append(c),
+            idle_timeout=1,
+            config_reloading=config_reloading,
+        )
+        # startup call + EXISTS call: the loop ran as usual
+        assert len(calls) == 2
+        # config_reloading was consulted at the top of each cycle
+        assert len(reload_calls) >= 2
+
 
 class TestFetchMessage:
     def _client(self):
@@ -616,6 +657,38 @@ class TestOAuth2Login:
             oauth2_vendor="yahoo",
         )
         assert seen == {"vendor": "yahoo"}
+
+    def test_init_forwards_config_reloading_to_start_idle(self, monkeypatch):
+        # __init__ must pass config_reloading through to the IDLE loop so a
+        # long-running watcher can reload config / shut down while idle.
+        _stub_network(monkeypatch)
+        monkeypatch.setattr(
+            imapclient.IMAPClient, "login", lambda self, u, p: None
+        )
+        captured = {}
+        monkeypatch.setattr(
+            IMAPClient,
+            "_start_idle",
+            lambda self, cb, idle_timeout=30, config_reloading=None: captured.update(
+                cb=cb, idle_timeout=idle_timeout, config_reloading=config_reloading
+            ),
+        )
+
+        def reloader() -> bool:
+            return False
+
+        def on_idle(client):
+            pass
+
+        IMAPClient(
+            "host",
+            "u@example.com",
+            "secret",
+            idle_callback=on_idle,
+            config_reloading=reloader,
+        )
+        assert captured["cb"] is on_idle
+        assert captured["config_reloading"] is reloader
 
     def test_missing_credentials_raises(self):
         with pytest.raises(ValueError, match="password or an OAuth2"):

--- a/tests/test_mailbox_imap.py
+++ b/tests/test_mailbox_imap.py
@@ -126,6 +126,36 @@ class TestIMAPConnection:
         with pytest.raises(NotImplementedError, match="IMAP"):
             conn.send_message("a@example.com")
 
+    def test_watch_returns_when_config_reloading_truthy(self, monkeypatch):
+        # A truthy config_reloading at the top of the loop returns before any
+        # IMAPClient connection is attempted.
+        conn = _bare_connection()
+        client_calls = []
+        monkeypatch.setattr(
+            "mailsuite.mailbox.imap.IMAPClient",
+            lambda *a, **kw: client_calls.append(kw),
+        )
+        conn.watch(lambda c: None, 1, config_reloading=lambda: True)
+        assert client_calls == []
+
+    def test_watch_forwards_config_reloading_to_client(self, monkeypatch):
+        # config_reloading must thread through to the IMAPClient so the IDLE
+        # loop itself can honor it. Return False once (enter the loop, build a
+        # client) then True (exit after the connection returns).
+        conn = _bare_connection()
+        captured = {}
+        monkeypatch.setattr(
+            "mailsuite.mailbox.imap.IMAPClient",
+            lambda *a, **kw: captured.update(kw),
+        )
+        states = iter([False, True])
+
+        def config_reloading() -> bool:
+            return next(states)
+
+        conn.watch(lambda c: None, 1, config_reloading=config_reloading)
+        assert captured["config_reloading"] is config_reloading
+
     def test_oauth2_kwargs_forwarded_to_client(self, monkeypatch):
         captured = {}
 


### PR DESCRIPTION
IMAPClient._start_idle() blocked indefinitely and could only be left via a KeyboardInterrupt, so a caller's config_reloading callback was never consulted while idle-waiting. Long-running watchers (e.g. parsedmarc) therefore could not reload config or shut down gracefully on SIGTERM/SIGINT until new mail happened to arrive — under Kubernetes the pod was SIGKILLed after its grace period.

Thread an optional config_reloading callable through IMAPClient.__init__() and _start_idle(), and check it at the top of each IDLE cycle (while IDLE is still active, so the trailing idle_done() stays valid). When it returns truthy the loop breaks cleanly and control returns to the caller's watch loop, which already polls config_reloading between checks. IMAPConnection.watch() passes its existing config_reloading through to the client.

No behavior change when config_reloading is None (the default).