### PR TITLE
test(graph): cover message-level move_message

### DIFF
--- a/tests/test_mailbox_graph.py
+++ b/tests/test_mailbox_graph.py
@@ -382,6 +382,16 @@ class TestMessageOps:
         item = conn._client.users.by_user_id("x").messages.by_message_id("m5")
         assert item.deleted is True
 
+    def test_move_message(self):
+        conn = _make_conn()
+        conn._client.users.by_user_id("x").mail_folders._listing_pages = [
+            MagicMock(value=[MagicMock(id="folder-abc", display_name="Archive")]),
+        ]
+        conn.move_message("m6", "Archive")
+        item = conn._client.users.by_user_id("x").messages.by_message_id("m6")
+        assert item.moved_body is not None
+        assert item.moved_body.destination_id == "folder-abc"
+
 
 class TestFolderResolution:
     def test_finds_folder_by_display_name(self):


### PR DESCRIPTION
## Summary

`MSGraphConnection.move_message()` (`mailbox/graph.py:533-540`) resolves the target folder name to an id via `_find_folder_id_from_folder_path()`, then POSTs `MovePostRequestBody(destination_id=folder_id)` to `.messages.by_message_id(...).move`. This method had zero test coverage — `TestDoMoveFolder` covers folder-level move, but message-level move was untested, even though `FakeMessageItem` already had `move`/`move.post` scaffolding wired up and unused.

Found while auditing Graph SDK test coverage for a downstream consumer (parsedmarc).

## Test plan

- [x] Added `TestMessageOps::test_move_message`, following the existing `test_finds_folder_by_display_name` pattern for mocking folder resolution and the existing `test_delete_message` pattern for asserting on the fake message item's recorded call.
- [x] Verified the test actually catches a regression: temporarily forced `destination_id=None` in `move_message()` and confirmed the new test fails with a clear assertion error; reverted.
- [x] `pytest tests/` — 359 passed, 2 skipped (Docker-only, unrelated).
- [x] `ruff check mailsuite tests` — clean.
- [x] `pyright mailsuite` (forced latest per this repo's AGENTS.md) — 0 errors, 0 warnings.

Note: `ruff format --check` currently flags 14 files as needing reformatting on `master` itself (pre-existing, reproduced before my change) — likely a local ruff-version formatting-opinion difference, not something introduced here. Left untouched since fixing it would touch unrelated files.
