### PR TITLE
fix(gmail): oauth2_port was silently ignored by run_local_server

### DIFF
--- a/mailsuite/mailbox/gmail.py
+++ b/mailsuite/mailbox/gmail.py
@@ -62,7 +62,7 @@ def _get_creds(
             creds.refresh(Request())
         else:
             flow = InstalledAppFlow.from_client_secrets_file(credentials_file, scopes)
-            creds = flow.run_local_server(open_browser=False, oauth2_port=oauth2_port)
+            creds = flow.run_local_server(open_browser=False, port=oauth2_port)
         Path(token_file).parent.mkdir(parents=True, exist_ok=True)
         with Path(token_file).open("w") as token:
             token.write(creds.to_json())

--- a/tests/test_mailbox_gmail.py
+++ b/tests/test_mailbox_gmail.py
@@ -99,6 +99,38 @@ class TestGetCreds:
         assert called["scopes"] == ["scope1"]
         assert creds._with_subject == "user@example.com"
 
+    def test_installed_app_uses_configured_port(self, tmp_path, monkeypatch):
+        """Regression: _get_creds must pass oauth2_port as run_local_server's
+        `port` kwarg. run_local_server has no `oauth2_port` parameter, so an
+        `oauth2_port=` call previously fell into **kwargs and was silently
+        forwarded to authorization_url() as a meaningless query parameter —
+        the WSGI listener always bound the library's own default (8080)
+        regardless of the configured value."""
+        from mailsuite.mailbox import gmail as gmail_mod
+
+        token_path = tmp_path / "token.json"
+        creds_file = tmp_path / "client_secrets.json"
+        creds_file.write_text("{}")
+
+        fake_creds = MagicMock()
+        fake_creds.valid = True
+        fake_creds.to_json.return_value = "{}"
+        fake_flow = MagicMock()
+        fake_flow.run_local_server.return_value = fake_creds
+        monkeypatch.setattr(
+            gmail_mod.InstalledAppFlow,
+            "from_client_secrets_file",
+            classmethod(lambda cls, f, s: fake_flow),
+        )
+
+        gmail_mod._get_creds(
+            str(token_path), str(creds_file), ["scope"], oauth2_port=9999
+        )
+
+        fake_flow.run_local_server.assert_called_once_with(
+            open_browser=False, port=9999
+        )
+
 
 class TestCreateFolder:
     def test_archive_skipped(self):


### PR DESCRIPTION
## Summary

`GmailConnection._get_creds()` builds the interactive OAuth flow with:

```python
creds = flow.run_local_server(open_browser=False, oauth2_port=oauth2_port)
```

`InstalledAppFlow.run_local_server()` (from `google-auth-oauthlib`) has no `oauth2_port` parameter — the actual parameter is `port` (default `8080`). The mismatched `oauth2_port=` kwarg falls through into `run_local_server`'s `**kwargs`, which get forwarded to `authorization_url(**kwargs)` and end up as a meaningless query parameter on the generated Google authorization URL. Meanwhile the WSGI listener itself (`wsgiref.simple_server.make_server(bind_addr or host, port, ...)`) always uses the hardcoded default `port=8080`, regardless of what `GmailConnection`'s own `oauth2_port` constructor argument was set to.

Net effect: the `oauth2_port` config option is a complete no-op today — the local redirect listener always binds `8080` no matter what's configured, which breaks any deployment relying on a non-default port (e.g. because 8080 is already in use, or a firewall/port-forward is set up for a specific port).

Found while verifying a downstream consumer's (parsedmarc) Gmail API setup documentation against actual behavior, not assumed behavior.

## Fix

One-line: pass `port=oauth2_port` instead of `oauth2_port=oauth2_port`.

## Test plan

- [x] Added `TestGetCreds::test_installed_app_uses_configured_port`, following the existing `TestTokenFileMkdir` mocking convention (`monkeypatch` on `InstalledAppFlow.from_client_secrets_file`). Asserts `run_local_server` was called with `port=9999` (not `oauth2_port=9999`).
- [x] Verified the test actually catches the regression: reverted the fix locally, confirmed the new test fails with `AssertionError: expected call not found. Expected: run_local_server(open_browser=False, port=9999) / Actual: run_local_server(open_browser=False, oauth2_port=9999)`; re-applied the fix, confirmed it passes.
- [x] `pytest tests/` — 359 passed, 2 skipped (Docker-only, unrelated).
- [x] `ruff check mailsuite tests` — clean.
- [x] `pyright mailsuite` (forced latest per this repo's AGENTS.md) — 0 errors, 0 warnings.
